### PR TITLE
Added a way to send the OS to chatGPT

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 typer~=0.7.0
 requests~=2.28.2
 rich==13.3.1
+distro~=1.8.0

--- a/sgpt.py
+++ b/sgpt.py
@@ -62,14 +62,14 @@ def main(
     shell: bool = typer.Option(False, "--shell", "-s", help="Provide shell command as output."),
     execute: bool = typer.Option(False, "--execute", "-e", help="Used with --shell, will execute command."),
     code: bool = typer.Option(False, help="Provide code as output."),
-    send-os: bool = typer.Option(False, "--send-os-info", "-o", help="Used with --shell, also send OS information to chatGPT. Useful for OS-specific commands, such as updating."),
+    send_os: bool = typer.Option(False, "--send-os-info", "-o", help="Used with --shell, also send OS information to chatGPT. Useful for OS-specific commands, such as updating."),
     animation: bool = typer.Option(True, help="Typewriter animation."),
     spinner: bool = typer.Option(True, help="Show loading spinner during API request."),
 ):
     api_key = get_api_key()
     if shell:
         prompt = f"{prompt}. Provide only shell command as output."
-        if send-os:
+        if send_os:
             prompt = f"{prompt} The system is {platform.system()} {platform.release()}."
             if {platform.system()} == 'Linux':
                 prompt = f"{prompt} The Linux distribution is {distro.id()}."

--- a/sgpt.py
+++ b/sgpt.py
@@ -1,6 +1,8 @@
 import os
 from time import sleep
 from pathlib import Path
+import distro
+import platform
 
 import typer
 import requests
@@ -60,12 +62,17 @@ def main(
     shell: bool = typer.Option(False, "--shell", "-s", help="Provide shell command as output."),
     execute: bool = typer.Option(False, "--execute", "-e", help="Used with --shell, will execute command."),
     code: bool = typer.Option(False, help="Provide code as output."),
+    send-os: bool = typer.Option(False, "--send-os-info", "-o", help="Used with --shell, also send OS information to chatGPT. Useful for OS-specific commands, such as updating."),
     animation: bool = typer.Option(True, help="Typewriter animation."),
     spinner: bool = typer.Option(True, help="Show loading spinner during API request."),
 ):
     api_key = get_api_key()
     if shell:
         prompt = f"{prompt}. Provide only shell command as output."
+        if send-os:
+            prompt = f"{prompt} The system is {platform.system()} {platform.release()}."
+            if {platform.system()} == 'Linux':
+                prompt = f"{prompt} The Linux distribution is {distro.id()}."
     elif code:
         prompt = f"{prompt}. Provide only code as output."
     response_text = openai_request(prompt, model, max_tokens, api_key, spinner=spinner)


### PR DESCRIPTION
For some commands, such as updating the system, chatGPT might need to know what OS the user is running. That is why I added an argument (`--send-os-info`, shortened to `-o`) to send some information to chatGPT. It sends the OS (`Linux`, `Darwin` or `Windows`), the version (kernel version on Linux, release on Windows), and, if on Linux, it also sends the distribution name (e.g. `opensuse-tumbleweed`).