### PR TITLE
Fix unicode exception

### DIFF
--- a/sgpt.py
+++ b/sgpt.py
@@ -58,7 +58,7 @@ def openai_request(prompt, model, max_tokens, api_key):
     }
     response = requests.post(API_URL, headers=headers, json=data, timeout=180)
     response.raise_for_status()
-    return response.json()["choices"][0]["text"]
+    return response.json()["choices"][0]["text"].encode().decode("unicode-escape") 
 
 
 def typer_writer(text, code, shell, animate):


### PR DESCRIPTION
When I use Chinese, sometimes the following happens

```
# sgpt "Mac Python脚本配置PATH"
"\u5c24\u5176\u662f\u5728Mac\u4e0a\u5b89\u88c5Python\u540e\uff0c\u7cfb\u7edf\u4f1a\u81ea\u52a8\u8bbe\u7f6ePython\u811a\u672c\u7684PATH\u3002\u4f8b\u5982\uff0c\u914d\u7f6ePATH\u6307\u5b9a\u201c/usr/local/bin\u201d\uff0c\u5219Python\u811a\u672c\u53ef\u4ee5\u901a\u8fc7\u201c/usr/local/bin/python\u201d\u5411Mac\u6307\u793a  \u8981\u4f7f\u7528Python\u3002
```