### PR TITLE
enable to change the api host by shell param

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ This is, just some examples of what we can do using ChatGPT model, I'm sure you 
 │ --cache                                       Cache completion results. [default: cache]                  │
 │ --animation                                   Typewriter animation. [default: animation]                  │
 │ --spinner                                     Show loading spinner during API request. [default: spinner] │
-│ --api-host                                Set other proxy API host. [default: https://api.openai.com] │
+│ --api-host         TEXT                       Set other proxy API host. [default: https://api.openai.com] │
 │ --help                                        Show this message and exit.                                 │
 ╰───────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 ```

--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ This is, just some examples of what we can do using ChatGPT model, I'm sure you 
 │ --cache                                       Cache completion results. [default: cache]                  │
 │ --animation                                   Typewriter animation. [default: animation]                  │
 │ --spinner                                     Show loading spinner during API request. [default: spinner] │
+│ --api-host         TEXT                       Set other proxy API host. [default: https://api.openai.com] │
 │ --help                                        Show this message and exit.                                 │
 ╰───────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 ```

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ This is, just some examples of what we can do using ChatGPT model, I'm sure you 
 │ --cache                                       Cache completion results. [default: cache]                  │
 │ --animation                                   Typewriter animation. [default: animation]                  │
 │ --spinner                                     Show loading spinner during API request. [default: spinner] │
-│ --api-host         TEXT                       Set other proxy API host. [default: https://api.openai.com] │
+│ --api-host                                Set other proxy API host. [default: https://api.openai.com] │
 │ --help                                        Show this message and exit.                                 │
 ╰───────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 ```

--- a/sgpt/app.py
+++ b/sgpt/app.py
@@ -96,6 +96,7 @@ def get_completion(
     top_p: float,
     caching: bool,
     chat: str,
+    api_host: str,
 ) -> str:
     """
     Generates completions for a given prompt using the OpenAI API.
@@ -108,7 +109,7 @@ def get_completion(
     :param chat: Enable/Disable conversation (chat mode).
     :return: GPT-3.5 generated completion.
     """
-    chat_gpt = ChatGPT(api_key)
+    chat_gpt = ChatGPT(api_key, api_host)
     model = "gpt-3.5-turbo"
     if not chat:
         return chat_gpt.get_completion(prompt, model, temperature, top_p, caching)
@@ -176,6 +177,7 @@ def main(
     cache: bool = typer.Option(True, help="Cache completion results."),
     animation: bool = typer.Option(True, help="Typewriter animation."),
     spinner: bool = typer.Option(True, help="Show loading spinner during API request."),
+    api_host: str = typer.Option("https://api.openai.com", help="Set other proxy API host."),
 ) -> None:
     if list_chat:
         echo_chat_ids()
@@ -199,7 +201,7 @@ def main(
 
     api_key = get_api_key()
     response_text = get_completion(
-        prompt, api_key, temperature, top_probability, cache, chat, spinner=spinner
+        prompt, api_key, temperature, top_probability, cache, chat, api_host, spinner=spinner
     )
 
     if code:

--- a/sgpt/chat_gpt.py
+++ b/sgpt/chat_gpt.py
@@ -137,18 +137,19 @@ class ChatGPT:
     OpenAI ChatGPT API interface.
     """
 
-    API_URL = "https://api.openai.com/v1/chat/completions"
+    # API_URL = API_HOST+"/v1/chat/completions"
     TEMP_FILE = Path(gettempdir()) / "shell_gpt_cache.json"
     chat_cache = ChatCache(length=50)
     cache = Cache(length=200)
 
-    def __init__(self, api_key: str):
+    def __init__(self, api_key: str, api_host: str):
         """
         Initialize ChatGPT.
 
         :param api_key: OpenAI API key.
         """
         self.api_key = api_key
+        self.api_url = api_host + "/v1/chat/completions"
 
     @cache
     def __request(
@@ -175,7 +176,7 @@ class ChatGPT:
             "temperature": temperature,
             "top_p": top_probability,
         }
-        response = requests.post(self.API_URL, headers=headers, json=data, timeout=30)
+        response = requests.post(self.api_url, headers=headers, json=data, timeout=30)
         response.raise_for_status()
         return response.json()
 


### PR DESCRIPTION
if this feature is implemented, users in country which cant access the OpenApi will be able 2 use sgpt without VPN (by hosting their own foreign api host proxy)
usage will be like below:
![image](https://user-images.githubusercontent.com/8627326/223927439-89d6f6d7-3154-42dd-a71b-0f578b623c3f.png)
