### PR TITLE
feat: get api key from OPENAI_API_KEY environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ A command-line productivity tool powered by OpenAI's ChatGPT (GPT-3.5). As devel
 ```shell
 pip install shell-gpt --user
 ```
-On first start you would need to generate and provide your API key, get one [here](https://beta.openai.com/account/api-keys).
+You'll need an OpenAI API key, you can generate one [here](https://beta.openai.com/account/api-keys).
+
+If the`$OPENAI_API_KEY` environment variable is set it will be used, otherwise, you will be prompted for your key which will then be stored in `~/.config/shell-gpt/api-key.txt`.
 
 ## Usage
 `sgpt` has a variety of use cases, including simple queries, shell queries, and code queries.

--- a/sgpt/app.py
+++ b/sgpt/app.py
@@ -40,6 +40,10 @@ def get_api_key() -> str:
 
     :return: String API key for OpenAI API requests.
     """
+
+    if "OPENAI_API_KEY" in os.environ:
+        return os.environ["OPENAI_API_KEY"]
+
     if not KEY_FILE.exists():
         api_key = getpass(prompt="Please enter your API secret key")
         KEY_FILE.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Try to get the api key from the OPENAI_API_KEY environment variable before prompting user. 

This also avoids storing active api keys in unencrypted text files.