### PR TITLE
Supporting FreeBSD (Add more OS recognition)

### DIFF
--- a/sgpt/make_prompt.py
+++ b/sgpt/make_prompt.py
@@ -71,6 +71,7 @@ def shell(question: str) -> str:
             "Windows": "Windows " + platform.release(),
             "Darwin": "Darwin/MacOS " + platform.mac_ver()[0],
             "FreeBSD": "FreeBSD " + platform.release()
+            # TODO: "BSD": "BSD/" + platform.system() + " " + platform.release()
         }
         return operating_systems.get(platform.system(), "Unknown")
 

--- a/sgpt/make_prompt.py
+++ b/sgpt/make_prompt.py
@@ -70,6 +70,7 @@ def shell(question: str) -> str:
             "Linux": "Linux/" + distro_name(pretty=True),
             "Windows": "Windows " + platform.release(),
             "Darwin": "Darwin/MacOS " + platform.mac_ver()[0],
+            "FreeBSD": "FreeBSD " + platform.release()
         }
         return operating_systems.get(platform.system(), "Unknown")
 


### PR DESCRIPTION
I would like to say that with add one line, shell_gpt supporting FreeBSD.
I don't know how get all BSDs family, so I put a template on file

![image](https://user-images.githubusercontent.com/19889081/226870709-df43677c-d1ec-4fcc-b316-99e687f8c309.png)
