### PR TITLE
Add --refine option to continue a conversation

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,8 @@ sgpt 'Which letter comes after K in the alphabet?'
 sgpt -r "And the next?'
 # -> The letter that comes after L in the alphabet is M.
 ```
-You can also maintain multiple chat sessions in parallel.
-To start a chat session, use the `--chat` option followed by a unique session name and a prompt:
+You can also maintain multiple chat sessions in parallel, by naming them.
+To start a named chat session, use the `--chat` option followed by a unique session name and a prompt:
 ```shell
 sgpt --chat number "please remember my favorite number: 4"
 # -> I will remember that your favorite number is 4.

--- a/README.md
+++ b/README.md
@@ -126,6 +126,14 @@ python fizz_buzz.py
 ```
 
 ### Chat
+You can ask followup queries to the current chat using the `--resume` option:
+```shell
+sgpt 'Which letter comes after K in the alphabet?'
+# -> The letter that comes after K in the alphabet is L.
+sgpt -r "And the next?'
+# -> The letter that comes after L in the alphabet is M.
+```
+You can also maintain multiple chat sessions in parallel.
 To start a chat session, use the `--chat` option followed by a unique session name and a prompt:
 ```shell
 sgpt --chat number "please remember my favorite number: 4"

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ python fizz_buzz.py
 ```
 
 ### Chat
-You can ask followup queries to the current chat using the `--resume` option:
+You can ask followup queries to the current chat using the `--refine` option:
 ```shell
 sgpt 'Which letter comes after K in the alphabet?'
 # -> The letter that comes after K in the alphabet is L.

--- a/sgpt/app.py
+++ b/sgpt/app.py
@@ -33,8 +33,8 @@ def get_completion(
     temperature: float,
     top_p: float,
     caching: bool,
-    chat: str,
     resume: bool,
+    chat: str,
 ):
     api_host = config.get("OPENAI_API_HOST")
     api_key = config.get("OPENAI_API_KEY")
@@ -45,8 +45,8 @@ def get_completion(
         temperature=temperature,
         top_probability=top_p,
         caching=caching,
-        chat_id=chat,
         resume=resume,
+        chat_id=chat,
     )
 
 
@@ -88,7 +88,7 @@ def main(
         prompt = make_prompt.code(prompt)
 
     completion = get_completion(
-        prompt, temperature, top_probability, cache, chat, resume, spinner=spinner
+        prompt, temperature, top_probability, cache, resume, chat, spinner=spinner
     )
 
     typer_writer(completion, code, shell, animation)

--- a/sgpt/app.py
+++ b/sgpt/app.py
@@ -33,7 +33,7 @@ def get_completion(
     temperature: float,
     top_p: float,
     caching: bool,
-    resume: bool,
+    refine: bool,
     chat: str,
 ):
     api_host = config.get("OPENAI_API_HOST")
@@ -45,7 +45,7 @@ def get_completion(
         temperature=temperature,
         top_probability=top_p,
         caching=caching,
-        resume=resume,
+        refine=refine,
         chat_id=chat,
     )
 
@@ -54,7 +54,7 @@ def main(
     prompt: str = typer.Argument(None, show_default=False, help="The prompt to generate completions for."),
     temperature: float = typer.Option(1.0, min=0.0, max=1.0, help="Randomness of generated output."),
     top_probability: float = typer.Option(1.0, min=0.1, max=1.0, help="Limits highest probable tokens (words)."),
-    resume: bool = typer.Option(False, "--resume", "-r", help="Follow most recent conversation (chat mode)."),
+    refine: bool = typer.Option(False, "--refine", "-r", help="Follow most recent conversation (chat mode)."),
     chat: str = typer.Option(None, help="Follow conversation with id (chat mode)."),
     show_chat: str = typer.Option(None, help="Show all messages from provided chat id."),
     list_chat: bool = typer.Option(False, help="List all existing chat ids."),
@@ -88,7 +88,7 @@ def main(
         prompt = make_prompt.code(prompt)
 
     completion = get_completion(
-        prompt, temperature, top_probability, cache, resume, chat, spinner=spinner
+        prompt, temperature, top_probability, cache, refine, chat, spinner=spinner
     )
 
     typer_writer(completion, code, shell, animation)

--- a/sgpt/app.py
+++ b/sgpt/app.py
@@ -34,6 +34,7 @@ def get_completion(
     top_p: float,
     caching: bool,
     chat: str,
+    followup: bool,
 ):
     api_host = config.get("OPENAI_API_HOST")
     api_key = config.get("OPENAI_API_KEY")
@@ -45,6 +46,7 @@ def get_completion(
         top_probability=top_p,
         caching=caching,
         chat_id=chat,
+        followup=followup,
     )
 
 
@@ -53,6 +55,7 @@ def main(
     temperature: float = typer.Option(1.0, min=0.0, max=1.0, help="Randomness of generated output."),
     top_probability: float = typer.Option(1.0, min=0.1, max=1.0, help="Limits highest probable tokens (words)."),
     chat: str = typer.Option(None, help="Follow conversation with id (chat mode)."),
+    followup: bool = typer.Option(False, "--followup", "-f", help="Follow current conversation."),
     show_chat: str = typer.Option(None, help="Show all messages from provided chat id."),
     list_chat: bool = typer.Option(False, help="List all existing chat ids."),
     shell: bool = typer.Option(False, "--shell", "-s", help="Provide shell command as output."),
@@ -85,7 +88,7 @@ def main(
         prompt = make_prompt.code(prompt)
 
     completion = get_completion(
-        prompt, temperature, top_probability, cache, chat, spinner=spinner
+        prompt, temperature, top_probability, cache, chat, followup, spinner=spinner
     )
 
     typer_writer(completion, code, shell, animation)

--- a/sgpt/app.py
+++ b/sgpt/app.py
@@ -34,7 +34,7 @@ def get_completion(
     top_p: float,
     caching: bool,
     chat: str,
-    followup: bool,
+    resume: bool,
 ):
     api_host = config.get("OPENAI_API_HOST")
     api_key = config.get("OPENAI_API_KEY")
@@ -46,7 +46,7 @@ def get_completion(
         top_probability=top_p,
         caching=caching,
         chat_id=chat,
-        followup=followup,
+        resume=resume,
     )
 
 
@@ -54,8 +54,8 @@ def main(
     prompt: str = typer.Argument(None, show_default=False, help="The prompt to generate completions for."),
     temperature: float = typer.Option(1.0, min=0.0, max=1.0, help="Randomness of generated output."),
     top_probability: float = typer.Option(1.0, min=0.1, max=1.0, help="Limits highest probable tokens (words)."),
+    resume: bool = typer.Option(False, "--resume", "-r", help="Follow most recent conversation (chat mode)."),
     chat: str = typer.Option(None, help="Follow conversation with id (chat mode)."),
-    followup: bool = typer.Option(False, "--followup", "-f", help="Follow current conversation."),
     show_chat: str = typer.Option(None, help="Show all messages from provided chat id."),
     list_chat: bool = typer.Option(False, help="List all existing chat ids."),
     shell: bool = typer.Option(False, "--shell", "-s", help="Provide shell command as output."),
@@ -88,7 +88,7 @@ def main(
         prompt = make_prompt.code(prompt)
 
     completion = get_completion(
-        prompt, temperature, top_probability, cache, chat, followup, spinner=spinner
+        prompt, temperature, top_probability, cache, chat, resume, spinner=spinner
     )
 
     typer_writer(completion, code, shell, animation)

--- a/sgpt/cache.py
+++ b/sgpt/cache.py
@@ -85,8 +85,8 @@ class ChatCache:
         """
         def wrapper(*args, **kwargs):
             chat_id = kwargs.pop("chat_id", None)
-            followup = kwargs.pop("followup", False)
-            if followup and not chat_id:
+            resume = kwargs.pop("resume", False)
+            if resume and not chat_id:
                 chat_id = self._read_current_chatid()
                 #print("Resuming chat: " + chat_id)
             message = {"role": "user", "content": kwargs.pop("message")}

--- a/sgpt/cache.py
+++ b/sgpt/cache.py
@@ -2,6 +2,7 @@ import json
 from hashlib import md5
 from pathlib import Path
 from typing import List, Dict, Callable
+from uuid import uuid4
 
 
 class Cache:
@@ -84,15 +85,22 @@ class ChatCache:
         """
         def wrapper(*args, **kwargs):
             chat_id = kwargs.pop("chat_id", None)
+            followup = kwargs.pop("followup", False)
+            if followup and not chat_id:
+                chat_id = self._read_current_chatid()
+                #print("Resuming chat: " + chat_id)
             message = {"role": "user", "content": kwargs.pop("message")}
             if not chat_id:
-                kwargs["message"] = [message]
-                return func(*args, **kwargs)
+                #kwargs["message"] = [message]
+                #return func(*args, **kwargs)
+                # Every query now gets a chat id
+                chat_id = str(uuid4())[:16]
             kwargs["message"] = self._read(chat_id)
             kwargs["message"].append(message)
             response_text = func(*args, **kwargs)
             kwargs["message"].append({"role": "assistant", "content": response_text})
             self._write(kwargs["message"], chat_id)
+            self._write_current_chatid(chat_id)
             return response_text
         return wrapper
 
@@ -106,6 +114,18 @@ class ChatCache:
     def _write(self, messages: List[Dict], chat_id: str):
         file_path = self.storage_path / chat_id
         json.dump(messages[-self.length:], file_path.open("w"))
+
+    def _write_current_chatid(self, chat_id: str):
+        file_path = self.storage_path / "CURRENT"
+        # Technically we could skip the json-encoding and decoding, since chat_id is just one string
+        json.dump(chat_id, file_path.open("w"))
+
+    def _read_current_chatid(self):
+        file_path = self.storage_path / "CURRENT"
+        if not file_path.exists():
+            return ""
+        parsed_current = json.loads(file_path.read_text())
+        return parsed_current
 
     def invalidate(self, chat_id: str):
         file_path = self.storage_path / chat_id

--- a/sgpt/cache.py
+++ b/sgpt/cache.py
@@ -85,14 +85,14 @@ class ChatCache:
         :return: Wrapped function with chat caching.
         """
         def wrapper(*args, **kwargs):
-            resume = kwargs.pop("resume", False)
+            refine = kwargs.pop("refine", False)
             chat_id = kwargs.pop("chat_id", None)
 
             # Decide which cache file to read from, and which to write to
             read_chat_id = chat_id
             write_chat_id = chat_id
             if not chat_id:
-                if not resume:
+                if not refine:
                     read_chat_id = None
                     write_chat_id = "unnamed"
                 else:

--- a/sgpt/cache.py
+++ b/sgpt/cache.py
@@ -89,32 +89,31 @@ class ChatCache:
             chat_id = kwargs.pop("chat_id", None)
 
             # Decide which cache file to read from, and which to write to
+            # This will set a chat_id, if none exists
             read_chat_id = chat_id
-            write_chat_id = chat_id
             if not chat_id:
                 if not refine:
                     # Starting a new unnamed chat
                     read_chat_id = None
-                    write_chat_id = "unnamed"
+                    chat_id = "unnamed"
                 else:
                     chat_id = self._read_current_chatid()
                     if chat_id == "unnamed":
                         # First reply to the unnamed chat
                         read_chat_id = "unnamed"
-                        write_chat_id = "".join(choice(hexdigits) for _ in range(32))
-                        #print("Converting " + read_chat_id + " chat into: " + write_chat_id)
+                        chat_id = "".join(choice(hexdigits) for _ in range(32))
+                        #print("Converting " + read_chat_id + " chat into: " + chat_id)
                     else:
                         # Replying to a named chat
                         read_chat_id = chat_id
-                        write_chat_id = chat_id
 
             message = {"role": "user", "content": kwargs.pop("message")}
             kwargs["message"] = self._read(read_chat_id) if read_chat_id else []
             kwargs["message"].append(message)
             response_text = func(*args, **kwargs)
             kwargs["message"].append({"role": "assistant", "content": response_text})
-            self._write(kwargs["message"], write_chat_id)
-            self._write_current_chatid(write_chat_id)
+            self._write(kwargs["message"], chat_id)
+            self._write_current_chatid(chat_id)
             return response_text
         return wrapper
 

--- a/sgpt/cache.py
+++ b/sgpt/cache.py
@@ -93,15 +93,18 @@ class ChatCache:
             write_chat_id = chat_id
             if not chat_id:
                 if not refine:
+                    # Starting a new unnamed chat
                     read_chat_id = None
                     write_chat_id = "unnamed"
                 else:
                     chat_id = self._read_current_chatid()
                     if chat_id == "unnamed":
+                        # First reply to the unnamed chat
                         read_chat_id = "unnamed"
                         write_chat_id = "".join(choice(hexdigits) for _ in range(32))
                         #print("Converting " + read_chat_id + " chat into: " + write_chat_id)
                     else:
+                        # Replying to a named chat
                         read_chat_id = chat_id
                         write_chat_id = chat_id
 

--- a/sgpt/cache.py
+++ b/sgpt/cache.py
@@ -84,8 +84,8 @@ class ChatCache:
         :return: Wrapped function with chat caching.
         """
         def wrapper(*args, **kwargs):
-            chat_id = kwargs.pop("chat_id", None)
             resume = kwargs.pop("resume", False)
+            chat_id = kwargs.pop("chat_id", None)
             if resume and not chat_id:
                 chat_id = self._read_current_chatid()
                 #print("Resuming chat: " + chat_id)

--- a/sgpt/cache.py
+++ b/sgpt/cache.py
@@ -2,7 +2,8 @@ import json
 from hashlib import md5
 from pathlib import Path
 from typing import List, Dict, Callable
-from uuid import uuid4
+from secrets import choice
+from string import hexdigits
 
 
 class Cache:
@@ -98,7 +99,7 @@ class ChatCache:
                     chat_id = self._read_current_chatid()
                     if chat_id == "unnamed":
                         read_chat_id = "unnamed"
-                        write_chat_id = str(uuid4())[:16]
+                        write_chat_id = "".join(choice(hexdigits) for _ in range(32))
                         #print("Converting " + read_chat_id + " chat into: " + write_chat_id)
                     else:
                         read_chat_id = chat_id

--- a/sgpt/cache.py
+++ b/sgpt/cache.py
@@ -3,7 +3,8 @@ from hashlib import md5
 from pathlib import Path
 from typing import List, Dict, Callable
 from secrets import choice
-from string import hexdigits
+from string import ascii_lowercase, digits
+from datetime import datetime
 
 
 class Cache:
@@ -101,7 +102,7 @@ class ChatCache:
                     if chat_id == "unnamed":
                         # First reply to the unnamed chat
                         read_chat_id = "unnamed"
-                        chat_id = "".join(choice(hexdigits) for _ in range(32))
+                        chat_id = datetime.now().strftime("%Y-%m-%d-%H%M") + "-" + "".join(choice(ascii_lowercase + digits) for _ in range(12))
                         #print("Converting " + read_chat_id + " chat into: " + chat_id)
                     else:
                         # Replying to a named chat

--- a/sgpt/cache.py
+++ b/sgpt/cache.py
@@ -116,12 +116,12 @@ class ChatCache:
         json.dump(messages[-self.length:], file_path.open("w"))
 
     def _write_current_chatid(self, chat_id: str):
-        file_path = self.storage_path / "CURRENT"
+        file_path = self.storage_path / ".." / "current_chat_id"
         # Technically we could skip the json-encoding and decoding, since chat_id is just one string
         json.dump(chat_id, file_path.open("w"))
 
     def _read_current_chatid(self):
-        file_path = self.storage_path / "CURRENT"
+        file_path = self.storage_path / ".." / "current_chat_id"
         if not file_path.exists():
             return ""
         parsed_current = json.loads(file_path.read_text())


### PR DESCRIPTION
With `--resume` or `-r` shell_gpt will now continue the most recently used conversation.

Disadvantage:

- Every conversation, even if not named, will be given a `chat_id` and cached.

Example:

![Screenshot_20230323_151046](https://user-images.githubusercontent.com/911799/227129583-25f8d515-0278-466a-9964-6b65869a57ed.png)

Closes #78