### PR TITLE
Add access to system role. 

### DIFF
--- a/sgpt/config.py
+++ b/sgpt/config.py
@@ -9,6 +9,7 @@ CONFIG_FOLDER = os.path.expanduser("~/.config")
 CONFIG_PATH = Path(CONFIG_FOLDER) / "shell_gpt" / ".sgptrc"
 CHAT_CACHE_PATH = Path(gettempdir()) / "shell_gpt" / "chat_cache"
 CACHE_PATH = Path(gettempdir()) / "shell_gpt" / "cache"
+ROLE_STORAGE_PATH = Path(CONFIG_FOLDER) / "shell_gpt" / "roles"
 CHAT_CACHE_LENGTH = 100
 CACHE_LENGTH = 100
 REQUEST_TIMEOUT = 60
@@ -42,13 +43,19 @@ def init() -> None:
         config["CACHE_LENGTH"] = os.getenv("CACHE_LENGTH", str(CACHE_LENGTH))
         config["CACHE_PATH"] = os.getenv("CACHE_PATH", str(CACHE_PATH))
         config["REQUEST_TIMEOUT"] = os.getenv("REQUEST_TIMEOUT", str(REQUEST_TIMEOUT))
+        config["REQUEST_TIMEOUT"] = os.getenv("ROLE_STORAGE_PATH", str(ROLE_STORAGE_PATH))
         _write()
 
-    with open(CONFIG_PATH, "r", encoding="utf-8") as file:
-        for line in file:
-            if "=" in line:
-                key, value = line.strip().split("=")
-                config[key] = value
+    # New features may add new keys to config.
+    if "ROLE_STORAGE_PATH" not in config:
+        append("ROLE_STORAGE_PATH", str(ROLE_STORAGE_PATH))
+
+    _read()
+
+
+def append(key: str, value: str) -> None:
+    with open(CONFIG_PATH, encoding="utf-8", mode="a") as file:
+        file.write(f"{key}={value}\n")
 
 
 def get(key: str) -> str:
@@ -65,6 +72,14 @@ def _write() -> None:
             if key in os.environ:
                 continue
             file.write(f"{key}={value}\n")
+
+
+def _read() -> None:
+    with open(CONFIG_PATH, "r", encoding="utf-8") as file:
+        for line in file:
+            if "=" in line:
+                key, value = line.strip().split("=")
+                config[key] = value
 
 
 def put(key: str, value: str, write_file=True) -> None:

--- a/sgpt/handlers/default_handler.py
+++ b/sgpt/handlers/default_handler.py
@@ -14,9 +14,10 @@ class DefaultHandler(Handler):
         client: OpenAIClient,
         shell: bool = False,
         code: bool = False,
+        role: str = None,
         model: str = "gpt-3.5-turbo",
     ) -> None:
-        super().__init__(client)
+        super().__init__(client, role)
         self.client = client
         self.mode = CompletionModes.get_mode(shell, code)
         self.model = model

--- a/sgpt/handlers/handler.py
+++ b/sgpt/handlers/handler.py
@@ -3,11 +3,13 @@ from typing import List, Dict, Generator
 import typer
 
 from sgpt import OpenAIClient
+from sgpt.role import SystemRole
 
 
 class Handler:
-    def __init__(self, client: OpenAIClient):
+    def __init__(self, client: OpenAIClient, role: str = None) -> None:
         self.client = client
+        self.role = role
 
     def make_prompt(self, prompt) -> str:
         raise NotImplementedError
@@ -28,9 +30,20 @@ class Handler:
             caching=caching,
         )
 
+    def make_messages(self, prompt: str) -> List[Dict[str, str]]:
+        # TODO: Should be overridden in ChatHandler.
+        messages = []
+        if self.role:
+            role = SystemRole.get(self.role)
+            messages.append({"role": "system", "content": role.role})
+        else:
+            prompt = self.make_prompt(prompt)
+        messages.append({"role": "user", "content": prompt})
+        return messages
+
     def handle(self, prompt: str, **kwargs) -> str:
-        prompt = self.make_prompt(prompt)
-        messages = [{"role": "user", "content": prompt}]
+        messages = self.make_messages(prompt)
+        print(messages)
         full_completion = ""
         for word in self.get_completion(messages=messages, **kwargs):
             typer.secho(word, fg="magenta", bold=True, nl=False)

--- a/sgpt/role.py
+++ b/sgpt/role.py
@@ -1,0 +1,91 @@
+from pathlib import Path
+from typing import Dict
+
+import typer
+from sgpt import config
+from sgpt.utils import option_callback
+
+
+class SystemRole:
+    storage = Path(config.get("ROLE_STORAGE_PATH"))
+
+    def __init__(self, name: str, role: str) -> None:
+        self.storage.mkdir(parents=True, exist_ok=True)
+        self.name = name
+        self.role = role
+
+    @classmethod
+    def get(cls, name: str) -> "SystemRole":
+        file_path = cls.storage / f"{name}.txt"
+        print(file_path)
+        if not file_path.exists():
+            raise FileNotFoundError(f'Role "{name}" not found.')
+        return cls(name, role=file_path.read_text())
+
+    @classmethod
+    def create(cls, name: str) -> None:
+        if not name:
+            return
+        role = typer.prompt("Enter role description")
+        role = cls(name, role)
+        role.save()
+        raise typer.Exit()
+
+    @classmethod
+    @option_callback
+    def list(cls) -> None:
+        if not cls.storage.exists():
+            return
+        # Get all files in the folder.
+        files = cls.storage.glob("*")
+        # Sort files by last modification time in ascending order.
+        for path in sorted(files, key=lambda f: f.stat().st_mtime):
+            typer.echo(path)
+
+    @classmethod
+    @option_callback
+    def show(cls, name: str):
+        typer.echo(cls.get(name).role)
+
+    @property
+    def exists(self) -> bool:
+        return self.file_path.exists()
+
+    @property
+    def system_message(self) -> Dict[str, str]:
+        return {"role": "system", "content": self.role}
+
+    @property
+    def file_path(self) -> Path:
+        return self.storage / f"{self.name}.txt"
+
+    def save(self) -> None:
+        if self.exists:
+            typer.confirm(
+                f'Role "{self.name}" already exists, overwrite it?',
+                abort=True,
+            )
+        self.file_path.write_text(self.role, encoding="utf-8")
+
+
+    # if __name__ == "__main__":
+    #     check_and_setup_default_roles()
+    #     # This is just for testing.
+    #     save_role(
+    #         "test",
+    #         "Hello, You are a role testing AI."
+    #         "Please always respond with a more enthusiastic test response, "
+    #         "and all context provided.",
+    #         executable_returns=False,
+    #         prompt_structure="Hello, {prompt}!",
+    #         conversation_lead_in=[
+    #             {"role": "user", "content": "{shell} and os {os} Test Test"},
+    #             {"role": "assistant", "content": "{shell} and os {os} Test Test Test!"},
+    #         ],
+    #         echo=True,
+    #     )
+    #     _list_roles(echo=True)
+    #     _show_role("test", echo=True)
+    #
+    #     _show_role("code", echo=True)
+

--- a/sgpt/utils.py
+++ b/sgpt/utils.py
@@ -1,8 +1,10 @@
 import os
 from enum import Enum
 from tempfile import NamedTemporaryFile
+from typing import Callable
 
 from click import BadParameter
+import typer
 
 
 class CompletionModes(Enum):
@@ -39,3 +41,12 @@ def get_edited_prompt() -> str:
     if not output:
         raise BadParameter("Couldn't get valid PROMPT from $EDITOR")
     return output
+
+
+def option_callback(func: Callable) -> Callable:
+    def wrapper(cls, value):
+        if not value:
+            return
+        func(cls)
+        raise typer.Exit()
+    return wrapper


### PR DESCRIPTION
## This pull request adds access to the `system` role for better description of how a model is supposed to respond. 

In support of #68 

This is probably just a first stage implementation because it doesn't allow for the creation, storage, and recall of custom roles as exampled in #68. Instead it simply adds a `--system` argument that can be used to append a message with the role system to the query delivered to the API. 

If no `--system` argument is provided it delivers a default system message of:
```
DEFAULT_SYSTEM_MESSAGE = "You are shell-gpt, a helpful programming and system administration assistant."
``` 
This is editable in the config file. 

The `--code` and `--shell` arguments have also been converted over to deliver their instructions as the system role instead of a prompt prefix. As mentioned in a TODO on line 77 of `client.py`
```
        # TODO: Move prompt context to system role when GPT-4 will be available over API.
```

## Known Problems:
This solution interacts with chat history strangely, because a chat history can contain previous `system` role messages, and a new query on an old chat will just append the new `system` request to the chat. More testing is needed to see how this will interact, but preliminary gpt-3.5 seems to be fine with receiving multiple `system` messages and just obeys the most recent one. 

## Interactions with other active pull requests

GPT-4 appears to follow `system` role commands better. My pull request #85 interacts well with this upgrade. Clone [My Fork:main](https://github.com/lpurdy01/shell_gpt) if you want to use both at the same time. 