### PR TITLE
Add stdin input, make every prompt editable

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ sgpt "docker show all local images"
 sgpt "mass of sun"
 # -> = 1.99 × 10^30 kg
 ```
+Prompts can also be provided via stdin, and combined with prompt arguments
+```shell
+echo "what is the sun made of" | sgpt
+git diff | sgpt "create a commit message for this diff:"
+```
 ### Conversion
 Convert various units and measurements without having to search for the conversion formula or use a separate conversion website. You can convert units such as time, distance, weight, temperature, and more.
 ```shell
@@ -228,7 +233,8 @@ REQUEST_TIMEOUT=60
 │ --shell                                       Provide shell command as output.                            │
 │ --execute                                     Will execute --shell command.                               │
 │ --code                                        Provide code as output. [default: no-code]                  │
-│ --editor                                      Open $EDITOR to provide a prompt. [default: no-editor]      │
+│ --stdin-before                                Place stdin prompt before prompt argument instead of after  │
+│ --editor                                      Open $EDITOR to edit the prompt. [default: no-editor]       │
 │ --cache                                       Cache completion results. [default: cache]                  │
 │ --animation                                   Typewriter animation. [default: animation]                  │
 │ --spinner                                     Show loading spinner during API request. [default: spinner] │

--- a/sgpt/app.py
+++ b/sgpt/app.py
@@ -50,7 +50,8 @@ def get_completion(
 
 
 def main(
-    prompt: str = typer.Argument(None, show_default=False, help="The prompt to generate completions for."),
+    prompt: str | None = typer.Argument(
+        None, show_default=False, help="The prompt to generate completions for."),
     stdin_before: bool = typer.Option(False, "--stdin-before", "-b", help="Place stdin prompt before argument prompt, default is after."),
     temperature: float = typer.Option(1.0, min=0.0, max=1.0, help="Randomness of generated output."),
     top_probability: float = typer.Option(1.0, min=0.1, max=1.0, help="Limits highest probable tokens (words)."),

--- a/sgpt/app.py
+++ b/sgpt/app.py
@@ -51,6 +51,7 @@ def get_completion(
 
 def main(
     prompt: str = typer.Argument(None, show_default=False, help="The prompt to generate completions for."),
+    stdin_before: bool = typer.Option(False, help="Place stdin before after prompt argument, default is to place it after."),
     temperature: float = typer.Option(1.0, min=0.0, max=1.0, help="Randomness of generated output."),
     top_probability: float = typer.Option(1.0, min=0.1, max=1.0, help="Limits highest probable tokens (words)."),
     chat: str = typer.Option(None, help="Follow conversation with id (chat mode)."),
@@ -71,7 +72,7 @@ def main(
         echo_chat_messages(show_chat)
         return
     
-    prompt = combine_with_stdin_prompt(prompt)
+    prompt = combine_with_stdin_prompt(prompt,stdin_before)
 
     if not prompt and not editor:
         raise MissingParameter(param_hint="PROMPT", param_type="string")

--- a/sgpt/app.py
+++ b/sgpt/app.py
@@ -12,6 +12,7 @@ API Key is stored locally for easy use in future runs.
 
 
 import os
+import sys 
 
 import typer
 
@@ -74,7 +75,10 @@ def main(
         raise MissingParameter(param_hint="PROMPT", param_type="string")
 
     if editor:
-        prompt = get_edited_prompt()
+        if not prompt:
+            prompt = sys.stdin.read()
+            if not prompt:
+             prompt = get_edited_prompt()
 
     if shell:
         # If default values, make response more accurate.

--- a/sgpt/app.py
+++ b/sgpt/app.py
@@ -12,7 +12,7 @@ API Key is stored locally for easy use in future runs.
 
 
 import os
-
+from typing import Optional
 import typer
 
 # Click is part of typer.
@@ -50,7 +50,7 @@ def get_completion(
 
 
 def main(
-    prompt: str | None = typer.Argument(
+    prompt: Optional[str] = typer.Argument(
         None, show_default=False, help="The prompt to generate completions for."),
     stdin_before: bool = typer.Option(False, "--stdin-before", "-b", help="Place stdin prompt before argument prompt, default is after."),
     temperature: float = typer.Option(1.0, min=0.0, max=1.0, help="Randomness of generated output."),
@@ -72,8 +72,8 @@ def main(
     if show_chat:
         echo_chat_messages(show_chat)
         return
-    
-    prompt = combine_with_stdin_prompt(prompt,stdin_before)
+
+    prompt = combine_with_stdin_prompt(prompt, stdin_before)
 
     if not prompt and not editor:
         raise MissingParameter(param_hint="PROMPT", param_type="string")

--- a/sgpt/app.py
+++ b/sgpt/app.py
@@ -51,7 +51,7 @@ def get_completion(
 
 def main(
     prompt: str = typer.Argument(None, show_default=False, help="The prompt to generate completions for."),
-    stdin_before: bool = typer.Option(False, help="Place stdin before after prompt argument, default is to place it after."),
+    stdin_before: bool = typer.Option(False, "--stdin-before", "-b", help="Place stdin prompt before argument prompt, default is after."),
     temperature: float = typer.Option(1.0, min=0.0, max=1.0, help="Randomness of generated output."),
     top_probability: float = typer.Option(1.0, min=0.1, max=1.0, help="Limits highest probable tokens (words)."),
     chat: str = typer.Option(None, help="Follow conversation with id (chat mode)."),

--- a/sgpt/app.py
+++ b/sgpt/app.py
@@ -12,8 +12,6 @@ API Key is stored locally for easy use in future runs.
 
 
 import os
-import sys 
-import select
 
 import typer
 
@@ -26,6 +24,7 @@ from sgpt.utils import (
     echo_chat_messages,
     typer_writer,
     get_edited_prompt,
+    combine_with_stdin_prompt
 )
 
 
@@ -72,27 +71,13 @@ def main(
         echo_chat_messages(show_chat)
         return
     
-    stdinprompt:None|str = None
-    if select.select([sys.stdin], [], [], 0) != ([], [], []):
-        stdinprompt= sys.stdin.read().rstrip()
-    
-
-    combined:None|str = None
-    if prompt is None and stdinprompt is None:
-        combined = None
-    elif prompt is None:
-        combined = stdinprompt
-    elif stdinprompt is None:
-        combined = prompt
-    else:
-        combined = f"{stdinprompt}\n{prompt}"
-    prompt = combined
+    prompt = combine_with_stdin_prompt(prompt)
 
     if not prompt and not editor:
         raise MissingParameter(param_hint="PROMPT", param_type="string")
 
     if editor:
-        prompt = get_edited_prompt(stdinprompt)
+        prompt = get_edited_prompt(prompt)
 
     if shell:
         # If default values, make response more accurate.

--- a/sgpt/utils.py
+++ b/sgpt/utils.py
@@ -1,4 +1,6 @@
 import os
+import sys 
+import select
 from time import sleep
 from typing import Callable
 from tempfile import NamedTemporaryFile
@@ -84,3 +86,20 @@ def echo_chat_ids() -> None:
     # Prints all existing chat IDs to the console.
     for chat_id in OpenAIClient.chat_cache.list():
         typer.echo(chat_id)
+
+def combine_with_stdin_prompt(prompt):
+    stdinprompt:None|str = None
+    if select.select([sys.stdin], [], [], 0) != ([], [], []):
+        stdinprompt= sys.stdin.read().rstrip()
+    
+
+    combined:None|str = None
+    if prompt is None and stdinprompt is None:
+        combined = None
+    elif prompt is None:
+        combined = stdinprompt
+    elif stdinprompt is None:
+        combined = prompt
+    else:
+        combined = f"{stdinprompt}\n{prompt}"
+    return combined

--- a/sgpt/utils.py
+++ b/sgpt/utils.py
@@ -27,7 +27,7 @@ def loading_spinner(func: Callable) -> Callable:
     return wrapper
 
 
-def get_edited_prompt() -> str:
+def get_edited_prompt(input:str='') -> str:
     """
     Opens the user's default editor to let them
     input a prompt, and returns the edited text.
@@ -37,6 +37,8 @@ def get_edited_prompt() -> str:
     with NamedTemporaryFile(suffix=".txt", delete=False) as file:
         # Create file and store path.
         file_path = file.name
+        # Write input to file.
+        file.write(input.encode())
     editor = os.environ.get("EDITOR", "vim")
     # This will write text to file using $EDITOR.
     os.system(f"{editor} {file_path}")

--- a/sgpt/utils.py
+++ b/sgpt/utils.py
@@ -87,7 +87,7 @@ def echo_chat_ids() -> None:
     for chat_id in OpenAIClient.chat_cache.list():
         typer.echo(chat_id)
 
-def combine_with_stdin_prompt(prompt):
+def combine_with_stdin_prompt(prompt:str|None, stdin_before:bool):
     stdinprompt:None|str = None
     if select.select([sys.stdin], [], [], 0) != ([], [], []):
         stdinprompt= sys.stdin.read().rstrip()
@@ -101,5 +101,5 @@ def combine_with_stdin_prompt(prompt):
     elif stdinprompt is None:
         combined = prompt
     else:
-        combined = f"{stdinprompt}\n{prompt}"
+        combined = f"{stdinprompt}\n{prompt}"  if stdin_before else f"{prompt}\n{stdinprompt}" 
     return combined

--- a/sgpt/utils.py
+++ b/sgpt/utils.py
@@ -1,8 +1,8 @@
 import os
-import sys 
+import sys
 import select
 from time import sleep
-from typing import Callable
+from typing import Callable, Optional
 from tempfile import NamedTemporaryFile
 
 import typer
@@ -29,7 +29,7 @@ def loading_spinner(func: Callable) -> Callable:
     return wrapper
 
 
-def get_edited_prompt(input:str='') -> str:
+def get_edited_prompt(input: Optional[str]) -> str:
     """
     Opens the user's default editor to let them
     input a prompt, and returns the edited text.
@@ -88,12 +88,12 @@ def echo_chat_ids() -> None:
         typer.echo(chat_id)
 
 
-def combine_with_stdin_prompt(prompt: str | None, stdin_before: bool) -> str | None:
-    stdinprompt: None | str = None
+def combine_with_stdin_prompt(prompt: Optional[str], stdin_before: bool) -> Optional[str]:
+    stdinprompt: Optional[str] = None
     if select.select([sys.stdin], [], [], 0) != ([], [], []):
         stdinprompt = sys.stdin.read().rstrip()
 
-    combined: None | str = None
+    combined: Optional[str] = None
     if prompt is None and stdinprompt is None:
         combined = None
     elif prompt is None:

--- a/sgpt/utils.py
+++ b/sgpt/utils.py
@@ -39,8 +39,9 @@ def get_edited_prompt(input: Optional[str]) -> str:
     with NamedTemporaryFile(suffix=".txt", delete=False) as file:
         # Create file and store path.
         file_path = file.name
-        # Write input to file.
-        file.write(input.encode())
+        # If input is present, write it to the temp file
+        if input:
+            file.write(input.encode())
     editor = os.environ.get("EDITOR", "vim")
     # This will write text to file using $EDITOR.
     os.system(f"{editor} {file_path}")
@@ -94,11 +95,11 @@ def combine_with_stdin_prompt(prompt: Optional[str], stdin_before: bool) -> Opti
         stdinprompt = sys.stdin.read().rstrip()
 
     combined: Optional[str] = None
-    if prompt is None and stdinprompt is None:
+    if not prompt and not stdinprompt:
         combined = None
-    elif prompt is None:
+    elif not prompt:
         combined = stdinprompt
-    elif stdinprompt is None:
+    elif not stdinprompt:
         combined = prompt
     else:
         combined = f"{stdinprompt}\n{prompt}" if stdin_before else f"{prompt}\n{stdinprompt}"

--- a/sgpt/utils.py
+++ b/sgpt/utils.py
@@ -87,13 +87,13 @@ def echo_chat_ids() -> None:
     for chat_id in OpenAIClient.chat_cache.list():
         typer.echo(chat_id)
 
-def combine_with_stdin_prompt(prompt:str|None, stdin_before:bool):
-    stdinprompt:None|str = None
-    if select.select([sys.stdin], [], [], 0) != ([], [], []):
-        stdinprompt= sys.stdin.read().rstrip()
-    
 
-    combined:None|str = None
+def combine_with_stdin_prompt(prompt: str | None, stdin_before: bool) -> str | None:
+    stdinprompt: None | str = None
+    if select.select([sys.stdin], [], [], 0) != ([], [], []):
+        stdinprompt = sys.stdin.read().rstrip()
+
+    combined: None | str = None
     if prompt is None and stdinprompt is None:
         combined = None
     elif prompt is None:
@@ -101,5 +101,5 @@ def combine_with_stdin_prompt(prompt:str|None, stdin_before:bool):
     elif stdinprompt is None:
         combined = prompt
     else:
-        combined = f"{stdinprompt}\n{prompt}"  if stdin_before else f"{prompt}\n{stdinprompt}" 
+        combined = f"{stdinprompt}\n{prompt}" if stdin_before else f"{prompt}\n{stdinprompt}"
     return combined


### PR DESCRIPTION
This pull request adds support for optionally receiving a prompt from stdin. Also --editor  now allows you to edit prompt regardless of prompt source. 

Usage:
```shell
git diff | sgpt "create a commit message for this diff" 
cat base_prompt.txt | sgpt --editor "additional prompt" 
```

sgpt will use either stdin prompt or argument prompt, and combine them if both are present. The --stdin-before / -b argument reverses the ordering of the two prompts when combined. 

Default ordering:
`echo "stdin prompt" | sgpt "argument prompt" `
```
argument prompt
stdin prompt
```

Reversed ordering:
`echo "stdin prompt" | sgpt --stdin-before "argument prompt" `
```
stdin prompt
argument prompt
```
