### PR TITLE
save code to file with --code

### DIFF
--- a/sgpt/app.py
+++ b/sgpt/app.py
@@ -104,7 +104,13 @@ def main(
     if not code and shell and typer.confirm("Execute shell command?"):
         os.system(full_completion)
 
+    if code:
+        filename = input("\nFilename (enter to cancel): ")
+        if filename:
+            with open(filename, 'w') as f:
+                f.write(full_completion)
 
+             
 def entry_point() -> None:
     # Python package entry point defined in setup.py
     typer.run(main)


### PR DESCRIPTION
When using the `--code` flag, this will save the generated code to a file of the user's choosing.

Normally, when the --code flag is passed, the script generates the output code but just prints it, not saving it to disk.

With this, the user will be prompted for a filename after the code generation is complete, and if one is provided provided, the generated code will be saved to that file.