### PR TITLE
Updated Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ USER app
 WORKDIR /home/app
 
 # Copy all files into the container
-COPY . /tmp/test
+COPY . /home/app
 
 # Set up Environment parameters
 # These are overriden if any of the variables are

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,38 @@
-FROM python:3-slim
+# Use Python 3 Slim as base image
+FROM python:3-slim AS shell_gpt
 
-ENV PYTHONDONTWRITEBYTECODE 1
-ENV PYTHONUNBUFFERED 1
-ENV PIP_ROOT_USER_ACTION ignore
-WORKDIR /app
-COPY . /app
-
-RUN pip install --no-cache --upgrade pip \
- && pip install --no-cache /app \
- && addgroup --system app && adduser --system --group app \
- && mkdir -p /tmp/shell_gpt \
- && chown -R app:app /tmp/shell_gpt
-
+# Create unprivileged user,
+# change to the new user 
+# and set docker workdir to user $HOME
+RUN adduser --system --group app
 USER app
+WORKDIR /home/app
 
+# Copy all files into the container
+COPY . /tmp/test
+
+# Set up Environment parameters
+# These are overriden if any of the variables are
+# set using '-e' when running the container
+ENV PATH="$PATH:$HOME/.local/bin:$HOME/bin" \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_ROOT_USER_ACTION=ignore \
+    OPENAI_API_KEY="your-OpenAI-API-key-here" \
+    OPENAI_API_HOST="https://api.openai.com" \
+    CHAT_CACHE_LENGTH=100 \
+    CHAT_CACHE_PATH="/tmp/shell_gpt/chat_cache" \
+    CACHE_LENGTH=100 \
+    CACHE_PATH="/tmp/shell_gpt/cache" \
+    REQUEST_TIMEOUT=60
+
+# Upgrade PIP and install Shell GPT via PIP
+RUN export PATH="$PATH:$HOME/.local/bin:$HOME/bin"; \
+    /usr/local/bin/pip install pip --no-cache --upgrade; \
+    /usr/local/bin/pip install --no-cache shell-gpt
+
+# Expose shell_gpt data volume
 VOLUME /tmp/shell_gpt
 
-ENTRYPOINT ["sgpt"]
-
+# Specify shell_gpt binary as entrypoint
+ENTRYPOINT ["/home/app/.local/bin/sgpt"]


### PR DESCRIPTION
Overall - fewer steps, cleaner looking Dockerfile

- Using `/home/app` as app directory and installing shell_gpt in user install mode oppose to installing system-wide in the container
- Adding initial shell_gpt config as ENV variables
- Setting multiple ENV params in a single step oppose to individual steps during Docker build
- Using full path to executables avoids potential errors like: `Error: crun: executable file `sgpt` not found in $PATH: No such file or directory: OCI runtime attempted to invoke a command that was not found`

Unsure why is this needed but I'm assuming it's for debugging/development purposes
```
# Copy all files into the container
COPY . /home/app
```