### PR TITLE
Prepend shell command with powershell if needed

### DIFF
--- a/sgpt/app.py
+++ b/sgpt/app.py
@@ -102,8 +102,10 @@ def main(
         full_completion += word
     typer.secho()
     if not code and shell and typer.confirm("Execute shell command?"):
-        os.system(full_completion)
-
+        if os.getenv("SHELL",'POWERSHELL'):
+            os.system('powershell.exe ' + full_completion)
+        else:
+            os.system(completion)
 
 def entry_point() -> None:
     # Python package entry point defined in setup.py


### PR DESCRIPTION
When running on windows the system will throw an error when the os call is made. This fix forces the shell to run the auto completion as powershell