### PR TITLE
Haim0n/feature/clean chat

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,3 @@
+black
+pylint
+requests_mock

--- a/sgpt/app.py
+++ b/sgpt/app.py
@@ -53,11 +53,19 @@ def main(
     chat: str = typer.Option(None, help="Follow conversation with id (chat mode)."),
     show_chat: str = typer.Option(None, help="Show all messages from provided chat id."),
     list_chat: bool = typer.Option(False, help="List all existing chat ids."),
+    delete_chat: bool = typer.Option(False, help="Delete provided chat id."),
     shell: bool = typer.Option(False, "--shell", "-s", help="Generate and execute shell command."),
     code: bool = typer.Option(False, help="Provide code as output."),
     editor: bool = typer.Option(False, help="Open $EDITOR to provide a prompt."),
     cache: bool = typer.Option(True, help="Cache completion results."),
 ) -> None:
+    if delete_chat:
+        if any((list_chat, show_chat)):
+            raise BadParameter(message="Ambigious: delete-chat, can't be used with other chat flags.")
+        if not chat or not OpenAIClient.chat_cache.exists(chat):
+            raise BadParameter(message="invalid or non existing", param_hint="chat")
+        OpenAIClient.chat_cache.invalidate(chat)
+        return
     if list_chat:
         echo_chat_ids()
         return

--- a/tests/unittests.py
+++ b/tests/unittests.py
@@ -4,6 +4,7 @@ import requests_mock
 import requests
 
 from sgpt import OpenAIClient
+from sgpt.config import config
 
 
 class TestMain(unittest.TestCase):
@@ -12,7 +13,7 @@ class TestMain(unittest.TestCase):
     # TODO: Fix tests.
 
     def setUp(self):
-        self.api_key = os.getenv("OPENAI_API_KEY")
+        self.api_key = config.get("OPENAI_API_KEY")
         assert self.api_key, "OPENAI_API_KEY ENV is required."
         self.prompt = "What is the capital of France?"
         self.shell = False


### PR DESCRIPTION
Two minor fixes:
1. Add requirements_dev.txt 
2. Fix `unittests.setUp` to attempt reading the `OPENAI_API_KEY` from local config or the env.

Feature:
1. Add `--delete-chat` flag to allow cleaning up existing chats.