### PR TITLE
Enable piping in extensive Data

### DIFF
--- a/sgpt/app.py
+++ b/sgpt/app.py
@@ -111,8 +111,14 @@ def main(
 ) -> None:
     stdin_passed = not sys.stdin.isatty()
 
-    if stdin_passed and not repl:
-        prompt = f"{sys.stdin.read()}\n\n{prompt or ''}"
+    if stdin_passed:
+        input_lines = sys.stdin.readlines()
+        prompt = "".join(input_lines) + "\n\n" + (prompt or "")
+        # Switch to stdin for interactive input
+        if os.name == "posix":
+            sys.stdin = open("/dev/tty", "r")
+        elif os.name == "nt":
+            sys.stdin = open("CON", "r")
 
     if not prompt and not editor and not repl:
         raise MissingParameter(param_hint="PROMPT", param_type="string")


### PR DESCRIPTION
I noticed that piping in file data with newlines broke the code responsible for handling pipes.

After a couple of lines (~4-8 if i remember correctly), it stopped and went into interactive mode. The rest of the pipe input was then used line for line, which was obviously not my intent.

To fix this, I changed the code to read all input from the pipe and then manually switch the pipe to stdin (/dev/tty or CON).
This therefore also allows to pipe in data for a REPL session.

Note: I haven't been able to test it on Windows yet, so I'm only 90% sure it will work.