### PR TITLE
Hide API key from Rich tracebacks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "requests >= 2.28.2, < 3.0.0",
     "typer >= 0.7.0, < 1.0.0",
     "click >= 7.1.1, < 9.0.0",
-    "rich >= 10.11.0, < 13.0.0",
+    "rich >= 13.1.0, < 14.0.0",
     "distro >= 1.8.0, < 2.0.0",
     'pyreadline3 >= 3.4.1, < 4.0.0; sys_platform == "win32"',
 ]

--- a/sgpt/app.py
+++ b/sgpt/app.py
@@ -129,9 +129,7 @@ def main(
     if editor:
         prompt = get_edited_prompt()
 
-    api_host = cfg.get("OPENAI_API_HOST")
-    __api_key = cfg.get("OPENAI_API_KEY")
-    client = OpenAIClient(api_host, __api_key)
+    client = OpenAIClient(cfg.get("OPENAI_API_HOST"), cfg.get("OPENAI_API_KEY"))
 
     role_class = DefaultRoles.get(shell, code) if not role else SystemRole.get(role)
 

--- a/sgpt/app.py
+++ b/sgpt/app.py
@@ -130,8 +130,8 @@ def main(
         prompt = get_edited_prompt()
 
     api_host = cfg.get("OPENAI_API_HOST")
-    api_key = cfg.get("OPENAI_API_KEY")
-    client = OpenAIClient(api_host, api_key)
+    __api_key = cfg.get("OPENAI_API_KEY")
+    client = OpenAIClient(api_host, __api_key)
 
     role_class = DefaultRoles.get(shell, code) if not role else SystemRole.get(role)
 

--- a/sgpt/client.py
+++ b/sgpt/client.py
@@ -15,8 +15,8 @@ REQUEST_TIMEOUT = int(cfg.get("REQUEST_TIMEOUT"))
 class OpenAIClient:
     cache = Cache(CACHE_LENGTH, CACHE_PATH)
 
-    def __init__(self, api_host: str, __api_key: str) -> None:
-        self.__api_key = __api_key
+    def __init__(self, api_host: str, api_key: str) -> None:
+        self.__api_key = api_key
         self.api_host = api_host
 
     @cache
@@ -37,10 +37,6 @@ class OpenAIClient:
         :param top_probability: Float in 0.0 - 1.0 range.
         :return: Response body JSON.
         """
-        headers = {
-            "Content-Type": "application/json",
-            "Authorization": "Bearer self.__api_key",
-        }
         data = {
             "messages": messages,
             "model": model,
@@ -50,7 +46,15 @@ class OpenAIClient:
         }
         endpoint = f"{self.api_host}/v1/chat/completions"
         response = requests.post(
-            endpoint, headers={**headers, "Authorization":f"Bearer {self.__api_key}"}, json=data, timeout=REQUEST_TIMEOUT, stream=True
+            endpoint,
+            # Hide API key from Rich traceback.
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {self.__api_key}",
+            },
+            json=data,
+            timeout=REQUEST_TIMEOUT,
+            stream=True,
         )
         response.raise_for_status()
         # TODO: Optimise.

--- a/sgpt/client.py
+++ b/sgpt/client.py
@@ -15,8 +15,8 @@ REQUEST_TIMEOUT = int(cfg.get("REQUEST_TIMEOUT"))
 class OpenAIClient:
     cache = Cache(CACHE_LENGTH, CACHE_PATH)
 
-    def __init__(self, api_host: str, api_key: str) -> None:
-        self.api_key = api_key
+    def __init__(self, api_host: str, __api_key: str) -> None:
+        self.__api_key = __api_key
         self.api_host = api_host
 
     @cache
@@ -39,7 +39,7 @@ class OpenAIClient:
         """
         headers = {
             "Content-Type": "application/json",
-            "Authorization": f"Bearer {self.api_key}",
+            "Authorization": "Bearer self.__api_key",
         }
         data = {
             "messages": messages,
@@ -50,7 +50,7 @@ class OpenAIClient:
         }
         endpoint = f"{self.api_host}/v1/chat/completions"
         response = requests.post(
-            endpoint, headers=headers, json=data, timeout=REQUEST_TIMEOUT, stream=True
+            endpoint, headers={**headers, "Authorization":f"Bearer {self.__api_key}"}, json=data, timeout=REQUEST_TIMEOUT, stream=True
         )
         response.raise_for_status()
         # TODO: Optimise.

--- a/sgpt/config.py
+++ b/sgpt/config.py
@@ -49,8 +49,8 @@ class Config(dict):  # type: ignore
             config_path.parent.mkdir(parents=True, exist_ok=True)
             # Don't write API key to config file if it is in the environment.
             if not defaults.get("OPENAI_API_KEY") and not os.getenv("OPENAI_API_KEY"):
-                api_key = getpass(prompt="Please enter your OpenAI API key: ")
-                defaults["OPENAI_API_KEY"] = api_key
+                __api_key = getpass(prompt="Please enter your OpenAI API key: ")
+                defaults["OPENAI_API_KEY"] = __api_key
             super().__init__(**defaults)
             self._write()
 


### PR DESCRIPTION
`Typer` uses `Rich` to format tracebacks with `show_locals=True` and `locals_hide_dunder=True`. This PR takes advantage of that second parameter to hide the user's API key (stored in `__api_key`) while retaining other local variables. (Issue #160)