### PR TITLE
Update maximum and default temperature values to match OpenAI Chat Completion API

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ Switch `SYSTEM_ROLES` to force use [system roles](https://help.openai.com/en/art
 ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ───────────────────────────────────────────────────────────────────────────────────────────────────╮
 │ --model            [gpt-3.5-turbo|gpt-4|gpt-4-32k]  OpenAI GPT model to use. [default: gpt-3.5-turbo]       │
-│ --temperature      FLOAT RANGE [0.0<=x<=1.0]        Randomness of generated output. [default: 0.1]          │
+│ --temperature      FLOAT RANGE [0.0<=x<=2.0]        Randomness of generated output. [default: 0.1]          │
 │ --top-probability  FLOAT RANGE [0.1<=x<=1.0]        Limits highest probable tokens (words). [default: 1.0]  │
 │ --editor                                            Open $EDITOR to provide a prompt. [default: no-editor]  │
 │ --cache                                             Cache completion results. [default: cache]              │

--- a/sgpt/app.py
+++ b/sgpt/app.py
@@ -34,7 +34,7 @@ def main(
     temperature: float = typer.Option(
         1.0,
         min=0.0,
-        max=1.0,
+        max=2.0,
         help="Randomness of generated output.",
     ),
     top_probability: float = typer.Option(

--- a/sgpt/app.py
+++ b/sgpt/app.py
@@ -32,7 +32,7 @@ def main(
         help="OpenAI GPT model to use.",
     ),
     temperature: float = typer.Option(
-        1.0,
+        0.1,
         min=0.0,
         max=2.0,
         help="Randomness of generated output.",

--- a/sgpt/app.py
+++ b/sgpt/app.py
@@ -32,7 +32,7 @@ def main(
         help="OpenAI GPT model to use.",
     ),
     temperature: float = typer.Option(
-        0.1,
+        1.0,
         min=0.0,
         max=1.0,
         help="Randomness of generated output.",

--- a/sgpt/client.py
+++ b/sgpt/client.py
@@ -33,7 +33,7 @@ class OpenAIClient:
 
         :param messages: List of messages {"role": user or assistant, "content": message_string}
         :param model: String gpt-3.5-turbo or gpt-3.5-turbo-0301
-        :param temperature: Float in 0.0 - 1.0 range.
+        :param temperature: Float in 0.0 - 2.0 range.
         :param top_probability: Float in 0.0 - 1.0 range.
         :return: Response body JSON.
         """


### PR DESCRIPTION
### Description

This pull request updates the maximum temperature value from 1 to 2 and the default temperature from 0.1 to 1 to align with the [OpenAI Chat Completion API](https://platform.openai.com/docs/api-reference/chat#chat/create-temperature). However, the change to the default temperature might be considered a **breaking change** for users. I can revert the default temperature change to avoid potential issues if this is a concern.

### Changes

1. Update the maximum temperature value from 1 to 2 in `app.py` and the documentation in `client.py`.
2. Update the default temperature value from 0.1 to 1 in `app.py`.

### Impact

This change ensures the code is consistent with the OpenAI Chat Completion API's temperature settings. However, users who rely on the current default value may experience different results after this update.

### Alternatives

1. Revert the default temperature change and only update the maximum temperature. This will avoid breaking changes for users but won't fully align with the OpenAI Chat Completion API.
2. Introduce a warning message for users about the change in default temperature value, prompting them to set a desired temperature to maintain the previous default explicitly.

--- 

Let me know if you have any feedback or concerns regarding the change, and thanks for creating this fantastic project!