### PR TITLE
Ignore comments in the .sgptrc config file

### DIFF
--- a/sgpt/config.py
+++ b/sgpt/config.py
@@ -68,8 +68,9 @@ class Config(dict):  # type: ignore
     def _read(self) -> None:
         with open(self.config_path, "r", encoding="utf-8") as file:
             for line in file:
-                key, value = line.strip().split("=")
-                self[key] = value
+                if not line.startswith("#"):
+                    key, value = line.strip().split("=")
+                    self[key] = value
 
     def get(self, key: str) -> str:  # type: ignore
         # Prioritize environment variables over config file.


### PR DESCRIPTION
The example config file provided on https://pypi.org/project/shell-gpt/ has comments which are not filtered out by default leading to an error when used as is.

This patch adds code to ignore all lines starting with # when the config file `.sgptrc` is read.