### PR TITLE
Add support for organization

### DIFF
--- a/sgpt/app.py
+++ b/sgpt/app.py
@@ -129,7 +129,7 @@ def main(
     if editor:
         prompt = get_edited_prompt()
 
-    client = OpenAIClient(cfg.get("OPENAI_API_HOST"), cfg.get("OPENAI_API_KEY"))
+    client = OpenAIClient(cfg.get("OPENAI_API_HOST"), cfg.get("OPENAI_API_KEY"), cfg.get("OPENAI_ORGANIZATION", False))
 
     role_class = DefaultRoles.get(shell, code) if not role else SystemRole.get(role)
 

--- a/sgpt/client.py
+++ b/sgpt/client.py
@@ -15,8 +15,9 @@ REQUEST_TIMEOUT = int(cfg.get("REQUEST_TIMEOUT"))
 class OpenAIClient:
     cache = Cache(CACHE_LENGTH, CACHE_PATH)
 
-    def __init__(self, api_host: str, api_key: str) -> None:
+    def __init__(self, api_host: str, api_key: str, organization: str) -> None:
         self.__api_key = api_key
+        self.__organization = organization
         self.api_host = api_host
 
     @cache
@@ -45,13 +46,18 @@ class OpenAIClient:
             "stream": True,
         }
         endpoint = f"{self.api_host}/v1/chat/completions"
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {self.__api_key}",
+        }
+
+        if self.__organization:
+            headers["OpenAI-Organization"] = self.__organization
+
         response = requests.post(
             endpoint,
             # Hide API key from Rich traceback.
-            headers={
-                "Content-Type": "application/json",
-                "Authorization": f"Bearer {self.__api_key}",
-            },
+            headers=headers,
             json=data,
             timeout=REQUEST_TIMEOUT,
             stream=True,

--- a/sgpt/config.py
+++ b/sgpt/config.py
@@ -71,10 +71,10 @@ class Config(dict):  # type: ignore
                 key, value = line.strip().split("=")
                 self[key] = value
 
-    def get(self, key: str) -> str:  # type: ignore
+    def get(self, key: str, required=True) -> str:  # type: ignore
         # Prioritize environment variables over config file.
         value = os.getenv(key) or super().get(key)
-        if not value:
+        if not value and required:
             raise UsageError(f"Missing config key: {key}")
         return value
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -321,10 +321,10 @@ class TestShellGpt(TestCase):
     def test_color_output(self):
         color = cfg.get("DEFAULT_COLOR")
         role = SystemRole.get("default")
-        handler = Handler(OpenAIClient("test", "test"), role=role)
+        handler = Handler(OpenAIClient("test", "test", "test"), role=role)
         assert handler.color == color
         os.environ["DEFAULT_COLOR"] = "red"
-        handler = Handler(OpenAIClient("test", "test"), role=role)
+        handler = Handler(OpenAIClient("test", "test", "test"), role=role)
         assert handler.color == "red"
 
     def test_simple_stdin(self):

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -14,6 +14,7 @@ class TestMain(unittest.TestCase):
 
     def setUp(self):
         self.api_key = os.environ["OPENAI_API_KEY"] = "test key"
+        self.organization = os.environ["OPENAI_ORGANIZATION"] = "test org"
         self.prompt = "What is the capital of France?"
         self.shell = False
         self.execute = False
@@ -24,7 +25,7 @@ class TestMain(unittest.TestCase):
         self.top_p = 1.0
         self.response_text = "Paris"
         self.model = "gpt-3.5-turbo"
-        self.client = OpenAIClient(self.API_HOST, self.api_key)
+        self.client = OpenAIClient(self.API_HOST, self.api_key, self.organization)
 
     @requests_mock.Mocker()
     def test_openai_request(self, mock):


### PR DESCRIPTION
This adds support for setting organization. When API usage is payed by a different account you need to set its organization ID. You can set it via environment or config.

I didn't want to change how prompting for the API key works because this should be the easy way to use `sgpt`. Most users wont need an organization so this would just confuse them.