### PR TITLE
Shell script

### DIFF
--- a/shell_gpt.sh
+++ b/shell_gpt.sh
@@ -142,32 +142,38 @@ _sgpt_override_enter_bash() {
 # If the command is not destructive or the user confirms, then return 0.
 # Otherwise, return 1.
 _sgpt_handle_destructive_command() {
-    local no_confirm_config_option='SHELL_EXECUTE_NO_CONFIRM'
-
-    # Get no-confirm configuration
-    local no_confirm
-    if [[ -f ~/.config/shell_gpt/.sgptrc ]]; then
-        no_confirm=$(grep -E '^${no_confirm_config_option}=' ~/.config/shell_gpt/.sgptrc \
-                | cut -d'=' -f2- | tr -d '[:space:]')
+    local config_path=~/.config/shell_gpt/.sgptrc
+    declare -A config_options=(
+        [no_confirm]='SHELL_EXECUTE_NO_CONFIRM'
+        [default_execute]='DEFAULT_EXECUTE_SHELL_CMD'
+    )
+    if [[ -f $config_path ]]; then
+        config_options[no_confirm]=$(. $config_path && eval echo \$$config_options[no_confirm])
+        config_options[default_execute]=$(. $config_path && eval echo \$$config_options[default_execute])
     fi
+
+    local confirm_string=$([[ $config_options[default_execute] == true ]] \
+                            && echo 'Y/n' || echo 'y/N')
 
     # If the command is destructive, then prompt for confirmation
     if _sgpt_is_destructive_command "$1"; then
         # Then prompt for confirmation
         echo -e "\033[1;31m${1}\033[0m" # Print the command in red
-        echo -e "Execute \033[1mdestructive\033[0m shell command? [y/N]:" # destructive in bold
+        echo -e "Execute \033[1mdestructive\033[0m shell command? [$confirm_string]:"
         read confirmation < /dev/tty
         # If user types enter or a word starting with n or N, then exit unsuccessfully
-        if [[ -z $confirmation || ${confirmation:0:1} == [nN] ]]; then
+        if [[ ($config_options[default_execute] != true \
+            && -z $confirmation) || ${confirmation:0:1} == [nN] ]]; then
             return 1
         fi
-    elif [[ $no_confirm != 'true' ]]; then
+    elif [[ $config_options[no_confirm] != true ]]; then
         # If the command is not destructive, then prompt for confirmation only if the
         # no-confirm configuration is not set to true.
         echo $1 # Print the command in green
-        echo "Execute shell command? [y/N]:"
+        echo "Execute shell command? [$confirm_string]:"
         read confirmation < /dev/tty
-        if [[ -z $confirmation || ${confirmation:0:1} == [nN] ]]; then
+        if [[ ($config_options[default_execute] != true \
+            && -z $confirmation) || ${confirmation:0:1} == [nN] ]]; then
             return 1
         fi
     fi

--- a/shell_gpt.sh
+++ b/shell_gpt.sh
@@ -83,7 +83,9 @@ command_not_found_handler() {
     fi
 
     # Convert the natural language to shell
+    printf '⌛'
     local converted_command=$(sgpt --shell <<< "$@")
+    printf "\r"
 
     # If it's destructive, then prompt for confirmation.
     if ! _sgpt_handle_destructive_command "$converted_command"; then

--- a/shell_gpt.sh
+++ b/shell_gpt.sh
@@ -25,7 +25,9 @@ _sgpt_zsh() {
         # If there is a mismatch (text changed between toggles), then the
         # result must be recalculated with sgpt.
         _sgpt_prev_cmd=$BUFFER
-        BUFFER=$(_sgpt_translate_buffer "$BUFFER")
+        BUFFER="$BUFFER ⌛"
+        zle redisplay
+        BUFFER=$(_sgpt_translate_buffer "$_sgpt_prev_cmd")
         _sgpt_penult_cmd=$BUFFER
     fi
     # Move cursor to end of line

--- a/shell_gpt.sh
+++ b/shell_gpt.sh
@@ -1,0 +1,172 @@
+# Default keybindings: zsh and bash have different syntax for keybindings.
+declare -A KEYBINDINGS=(
+    [toggle_zsh]='^@' # Control-Space
+    [nl_execute_zsh]='[27;5;13~' # Control-Enter
+    [toggle_bash]='\C-@'
+    [nl_execute_bash]='\C-M'
+)
+
+# Toggles the buffer between natural language and shell command, assuming
+# it executes in zsh.
+_sgpt_zsh() {
+    # In zsh, the text in the terminal is stored in BUFFER.
+    [[ -z $BUFFER ]] && BUFFER=$(fc -ln -1)
+
+    # Cache the answers when toggling (optimization). If the keybinding
+    # is pressed twice, then the first answer would already be stored.
+    if [[ $BUFFER == $_sgpt_penult_cmd ]]; then
+        # Swap the buffer and the previous cached result. Then store
+        # the command that is being translated.
+        tmp=$BUFFER
+        BUFFER=$_sgpt_prev_cmd
+        _sgpt_penult_cmd=$_sgpt_prev_cmd
+        _sgpt_prev_cmd=$tmp
+    else
+        # If there is a mismatch (text changed between toggles), then the
+        # result must be recalculated with sgpt.
+        _sgpt_prev_cmd=$BUFFER
+        BUFFER=$(_sgpt_translate_buffer "$BUFFER")
+        _sgpt_penult_cmd=$BUFFER
+    fi
+    # Move cursor to end of line
+    zle end-of-line
+}
+
+# Toggles the buffer between natural language and shell command, assuming
+# it executes in bash.
+_sgpt_bash() {
+    # Small modification over _sgpt_zsh: use READLINE_BUFFER instead of BUFFER.
+    # NOTE: These two functions could be merged using an indirect reference to the
+    # buffer variable given as a parameter, but the method that is compatible with 
+    # both zsh and bash is very messy: (https://tldp.org/LDP/abs/html/ivr.html)
+    [[ -z $READLINE_LINE ]] && READLINE_LINE=$(fc -ln -1)
+
+    if [[ $READLINE_LINE == $_sgpt_penult_cmd ]]; then
+        tmp=$READLINE_LINE
+        READLINE_LINE=$_sgpt_prev_cmd
+        _sgpt_penult_cmd=$_sgpt_prev_cmd
+        _sgpt_prev_cmd=$tmp
+    else
+        _sgpt_prev_cmd=$READLINE_LINE
+        READLINE_LINE=$(_sgpt_translate_buffer "$READLINE_LINE")
+        _sgpt_penult_cmd=$READLINE_LINE
+    fi
+    # Move cursor to end of line
+    READLINE_POINT=${#READLINE_LINE}
+}
+
+# Decides whether the buffer contains shell command or natural language, then translates
+# it to the other one using sgpt.
+_sgpt_translate_buffer() {
+    # The command name is the first word in the buffer
+    local command_name=${1%% *}
+    local sgpt_flag='--shell'
+
+    # Decide if the buffer contains command or natural language.
+    # If the first letter is lowercase and the command exists, then it is a command.
+    if [[ ${1:0:1} = [[:lower:]] ]] && command -v $command_name > /dev/null; then
+        sgpt_flag='--describe-shell'
+    fi
+
+    sgpt $sgpt_flag <<< $1
+}
+
+# Overrides the function that executes when a command is not found.
+# First, decide if the incorrect command is natural language. If it is, 
+# then translate to shell. If the translated command is destructive,
+# then prompt before executing. Otherwise, directly execute.
+command_not_found_handler() {
+    # Determines if the command is actually just shell by two conditions:
+    # 1. The first letter of the first word of the command is lowercased, and
+    # 2. The number of words is below some arbitrary threshold, because natural
+    #    language is much more verbose.
+    local nl_word_count_threshold=6
+    if [[ ${1:0:1} = [[:lower:]] && $(wc -w <<< "$@") -lt $nl_word_count_threshold ]]
+    then
+        # No need to translate, so return the exit code of the previous command
+        echo "command not found: $@"
+        return 1
+    fi
+
+    # Convert the natural language to shell
+    local converted_command=$(sgpt --shell <<< "$@")
+
+    # If it's destructive, then prompt for confirmation.
+    if _sgpt_is_destructive_command "$converted_command"; then
+        # Then prompt for confirmation
+        echo "$converted_command"
+        echo "Execute destructive shell command? [y/N]:"
+        read confirmation
+        # If user types enter or a word starting with n or N, then exit unsuccessfully
+        if [[ -z $confirmation || ${confirmation:0:1} == [nN] ]]; then
+            return 1
+        fi
+    fi
+
+    # Execute the translated command.
+    # TODO Use subshell to execute command instead because it is safer then eval.
+    eval "$converted_command"
+}
+
+# Same thing for bash, but slightly different function name
+command_not_found_handle() { 
+    command_not_found_handler "$@"
+}
+
+# Emulates the behavior of the above command_not_found_handler.
+# This is tricky because not pressing enter means the default behavior must be emulated,
+# but now assume the buffer contains natural language, allowing for queries starting
+# with a valid command. For example, "ls hidden files" -> "ls -a"
+# This is done in 3 steps
+#   1. Convert natural language and check if it's destructive
+#   2. Print new line, execute command, and print another new line
+#       This is done to emulate the default behavior of pressing enter
+#   3. Add the natural language to the history and clear the buffer
+_sgpt_override_enter_zsh() {
+    local converted_command=$(sgpt --shell <<< $BUFFER)
+    if _sgpt_is_destructive_command "$converted_command"; then
+        # Then prompt for confirmation
+        echo "$converted_command"
+        echo "Execute destructive shell command? [y/N]:"
+        read confirmation
+        # If user types enter or a word starting with n or N, then exit unsuccessfully
+        if [[ -z $confirmation || ${confirmation:0:1} == [nN] ]]; then
+            return 1
+        fi
+    fi
+
+    # Execute the translated command.
+    # TODO Use subshell to execute command instead because it is safer then eval.
+    echo
+    eval "$converted_command"
+    echo
+    print -s "$BUFFER"
+    BUFFER=''
+    zle reset-prompt
+}
+
+_sgpt_override_enter_bash() {
+    read -r -a args <<< "$READLINE_LINE"
+    command_not_found_handler "${args[@]}"
+}
+
+# Returns whether or not a given commands makes an irreversable change
+_sgpt_is_destructive_command() {
+    # HACK: This is not an exhaustive way to check if the command
+    # is destructive. There are flags in other common commands that
+    # should be checked.
+    local destructive_commands=(rm mv dd chmod sed git mkfs mkswap )
+    local command_name=${1%% *}
+    [[ "$destructive_commands[@]" =~ $command_name ]]
+}
+
+# Determine the type of shell, and execute the appropriate keybinding commmand
+if [[ -n $ZSH_VERSION ]]; then
+    zle -N _sgpt_zsh
+    zle -N _sgpt_override_enter_zsh
+    bindkey "${KEYBINDINGS[toggle_zsh]}" _sgpt_zsh
+    bindkey "${KEYBINDINGS[nl_execute_zsh]}" _sgpt_override_enter_zsh
+else
+    bind -x "\"${KEYBINDINGS[toggle_bash]}\": _sgpt_bash"
+    bind -x "\"${KEYBINDINGS[nl_execute_bash]}\": _sgpt_override_enter_bash"
+fi

--- a/shell_gpt.sh
+++ b/shell_gpt.sh
@@ -117,18 +117,17 @@ command_not_found_handle() {
 #   3. Add the natural language to the history and clear the buffer
 _sgpt_override_enter_zsh() {
     local converted_command=$(sgpt --shell <<< $BUFFER)
-    echo
+    zle -I
     if ! _sgpt_handle_destructive_command "$converted_command"; then
+        BUFFER=''
         return 1
     fi
 
-    # Execute the translated command.
-    # TODO Use subshell to execute command instead because it is safer then eval.
+    # Execute the translated command, add the natural language 
+    # to history, and clear the buffer
     eval "$converted_command"
-    echo
     print -s "$BUFFER"
     BUFFER=''
-    zle reset-prompt
 }
 
 _sgpt_override_enter_bash() {
@@ -147,10 +146,9 @@ _sgpt_handle_destructive_command() {
         # Then prompt for confirmation
         echo "$1"
         echo "Execute destructive shell command? [y/N]:"
-        read confirmation
+        read confirmation < /dev/tty
         # If user types enter or a word starting with n or N, then exit unsuccessfully
         if [[ -z $confirmation || ${confirmation:0:1} == [nN] ]]; then
-            echo "Cancelled"
             return 1
         fi
     fi

--- a/shell_gpt.sh
+++ b/shell_gpt.sh
@@ -18,7 +18,7 @@ _sgpt_zsh() {
         # result must be recalculated with sgpt.
         _sgpt_prev_cmd=$BUFFER
         BUFFER="$BUFFER ⌛"
-        zle redisplay
+        zle -I && zle redisplay
         BUFFER=$(_sgpt_translate_buffer "$_sgpt_prev_cmd" $1)
         _sgpt_penult_cmd=$BUFFER
     fi
@@ -116,7 +116,7 @@ command_not_found_handle() {
 _sgpt_override_enter_zsh() {
     local old_buffer=$BUFFER
     BUFFER="$BUFFER ⌛"
-    zle redisplay
+    zle -I && zle redisplay
     local converted_command=$(sgpt --shell <<< $old_buffer)
     BUFFER="$old_buffer"
     zle redisplay
@@ -232,9 +232,9 @@ _sgpt_is_destructive_command() {
 
 # Default keybindings
 declare -A KEYBINDINGS=(
-    [toggle_buffer]='\et' # Alt-t
-    [execute_natural_language]='\ee' # Alt-e
-    [toggle_natural_language]='\eT' # Alt-T
+    [toggle_buffer]='^t' # Alt-t
+    [execute_natural_language]='^e' # Alt-e
+    [toggle_natural_language]='^T' # Alt-T
 )
 
 # Override default keybindings with user defined keybindings

--- a/test_sgpt.sh
+++ b/test_sgpt.sh
@@ -1,0 +1,35 @@
+test_is_destructive_command() {
+    . ./shell_gpt.sh
+    declare -A tests=(
+        # 0 means destructive, 1 means safe
+        ['git status']=1
+        ['mv --no-clobber']=1
+        ['rm -rf']=0
+        ['ls -al']=1
+        ['dd -f']=0
+        ['sed -i']=0
+    )
+    for command in "${(k)tests[@]}"; do
+        _sgpt_is_destructive_command "$command"
+        [[ $? -eq ${tests[$command]} ]] || echo "Test failed for '$command'"
+    done
+}
+
+test_handle_destructive_command() {
+    . ./shell_gpt.sh
+    echo "Instructions: Enter 'n' for rm, 'y' for dd, nothing for sed, and 'n' for find"
+    declare -A tests=( 
+        # 0 means handled, 1 means abort
+        ['git status']=0
+        ['mv --no-clobber x y']=0
+        ['rm -rf folder']=1
+        ['ls -al']=0
+        ['dd if=~/a of=~/b']=0
+        ['sed -i "s/foo/bar/g" file.txt']=1
+        ['find . -type f -name "*.txt" -delete']=1
+    )
+    for command in "${(k)tests[@]}"; do
+        _sgpt_handle_destructive_command "$command"
+        [[ $? -eq ${tests[$command]} ]] || echo "Test failed for '$command'"
+    done
+}


### PR DESCRIPTION
Overrides command not found handler and implements 2 keybindings:
  1. **Control + Space**: Toggle the buffer between natural language and bash.
  2. **Enter**: If command not found, then if the command is natural language, translate and execute.
  3. **Control + Enter**: Execute the natural language in the buffer, regardless whether its also a valid bash command *("find all files longer than 20 lines")*. Also useful for Mac because of the uppercase commands.

One last feature to implement is more robust checking for destructive commands.