### PR TITLE
added a function to log shell commands executed by sgpt

### DIFF
--- a/sgpt/utils.py
+++ b/sgpt/utils.py
@@ -36,6 +36,20 @@ def get_edited_prompt() -> str:
         raise BadParameter("Couldn't get valid PROMPT from $EDITOR")
     return output
 
+def save_shell_history(command: str) -> None:
+    """
+    Creates a file in shell_gpt directory.
+    Filename is shell_history.
+    This file stores commands executed by sgpt.
+    """
+    current_file_path = os.path.realpath(__file__)
+    current_directory = os.path.dirname(current_file_path)
+    relative_path = "../shell_history"
+    absolute_path = os.path.join(current_directory, relative_path)
+    log_path = absolute_path
+    with open(log_path, "a", encoding="utf-8") as log:
+        log.write(f"{command}\n")
+
 
 def run_command(command: str) -> None:
     """
@@ -55,7 +69,7 @@ def run_command(command: str) -> None:
         full_command = f"{shell} -c {shlex.quote(command)}"
 
     os.system(full_command)
-
+    save_shell_history(command)
 
 def option_callback(func: Callable) -> Callable:  # type: ignore
     def wrapper(cls: Any, value: str) -> None:


### PR DESCRIPTION
## What is this PR for
As a system administrator, it is useful and required to know which commands are being executed in the system.
This PR adds the functionality to log shell commands executed by the sgpt. It only logs shell commands and does not log chat or code. 
It logs shell commands at the ***shell_gpt/shell_history*** location. 

## Test the added functionality
I have tested the added functionality and it is working as expected and not breaking any of the current functionality.

![image](https://github.com/TheR1D/shell_gpt/assets/68107671/f4630c90-0382-42b8-a6bf-130ac19d8eb4)

## Running scripts/lint.sh and scripts/test.sh
I have executed ***scripts/lint.sh*** and it gave the following output :

![image](https://github.com/TheR1D/shell_gpt/assets/68107671/90f7e27d-66e4-4f8c-8d34-210a4e142b71)

***scripts/test.sh*** is giving HTTPERROR 429 due to I am using free version of OpenAI API and it has nothing to do with the code changes. 