### PR TITLE
Create configuration parameter DEFAULT_EXECUTE_SHELL_CMD

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,8 @@ DEFAULT_MODEL=gpt-3.5-turbo
 DEFAULT_COLOR=magenta
 # Force use system role messages (not recommended).
 SYSTEM_ROLES=false
+# When in --shell mode, default to "Y" for no input.
+DEFAULT_EXECUTE_SHELL_CMD=false
 ```
 Possible options for `DEFAULT_COLOR`: black, red, green, yellow, blue, magenta, cyan, white, bright_black, bright_red, bright_green, bright_yellow, bright_blue, bright_magenta, bright_cyan, bright_white.
 

--- a/sgpt/app.py
+++ b/sgpt/app.py
@@ -162,7 +162,14 @@ def main(
             caching=cache,
         )
 
-    if shell and not stdin_passed and typer.confirm("Execute shell command?"):
+    if (
+        shell
+        and not stdin_passed
+        and typer.confirm(
+            text="Execute shell command?",
+            default=cfg.get("DEFAULT_EXECUTE_SHELL_CMD") == "true",
+        )
+    ):
         run_command(full_completion)
 
 

--- a/sgpt/config.py
+++ b/sgpt/config.py
@@ -28,6 +28,7 @@ DEFAULT_CONFIG = {
     "DEFAULT_COLOR": os.getenv("DEFAULT_COLOR", "magenta"),
     "ROLE_STORAGE_PATH": os.getenv("ROLE_STORAGE_PATH", str(ROLE_STORAGE_PATH)),
     "SYSTEM_ROLES": os.getenv("SYSTEM_ROLES", "false"),
+    "DEFAULT_EXECUTE_SHELL_CMD": os.getenv("DEFAULT_EXECUTE_SHELL_CMD", "false"),
     # New features might add their own config variables here.
 }
 


### PR DESCRIPTION
This addresses the following issue: https://github.com/TheR1D/shell_gpt/issues/185

I wanted a mechanism to automatically execute GPT-suggested shell commands without entering "y" for each command. Others have asked for this, so I decided to open the PR.

### Testing:

Testing the case where the environment variable is true:
```
% DEFAULT_EXECUTE_SHELL_CMD=true ./env/bin/python ./sgpt/app.py -s "2 + 3"
echo $((2+3))
Execute shell command? [Y/n]:
5
% 
```

Testing the case where the environment variable is false (default):
```
% DEFAULT_EXECUTE_SHELL_CMD=false ./env/bin/python ./sgpt/app.py -s "2 + 3"
echo $((2+3))
Execute shell command? [y/N]:
%
```

Users can set the parameter in their config file `~/.config/shell_gpt/.sgptrc` or as an environment variable. The parameter defaults to the value "false", so the behavior after merging this PR is the same as the present behavior. I've added a note in the README about this new parameter, and will put a comment in the open issue if this is accepted.

Tested locally, both `./scripts/lint.sh` and `./scripts/tests.sh` passed successfully. I did not add an integration test because it seems non-trivial to spin-up a test session which dynamically interacts with the response from the GPT runner given the current test framework. Happy to take any feedback on that, perhaps there is a simpler way that I'm not aware of.  