### PR TITLE
Add support for multiple words without quotes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,36 @@
+Create a new file named ".gitignore" in the root directory of your Python app and add the following lines:
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Local development settings
+.env
+
+# IDE files
+.vscode/
+.idea/
+
+# Dependency directories
+venv/
+env/
+env.bak/
+
+# Distribution / packaging
+dist/
+build/
+*.egg-info/
+*.egg
+
+# Compiled Python files
+*.pyc
+
+# Logs and databases
+*.log
+*.sqlite3
+
+# Other
+*.swp
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
This pull request adds functionality to allow the use of prompts with multiple words without requiring the words to be enclosed in quotes. This enhancement improves the usability of command-line interface and reduces potential errors that can occur from forgetting to use quotes. Additionally, this pull request includes a default .gitignore file for Python, improving the developer experience by excluding irrelevant files from version control.