### PR TITLE
Describe shell command before executing

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ https://user-images.githubusercontent.com/16740832/231569156-a3a9f9d4-18b1-4fff-
 
 ## Installation
 ```shell
-pip install shell-gpt==0.9.0
+pip install shell-gpt==0.9.1
 ```
 You'll need an OpenAI API key, you can generate one [here](https://beta.openai.com/account/api-keys).
 
@@ -45,25 +45,38 @@ Have you ever found yourself forgetting common shell commands, such as `chmod`, 
 ```shell
 sgpt --shell "make all files in current directory read only"
 # -> chmod 444 *
-# -> Execute shell command? [y/N]: y
-# ...
+# -> [E]xecute, [D]escribe, [A]bort: e
+...
 ```
 Shell GPT is aware of OS and `$SHELL` you are using, it will provide shell command for specific system you have. For instance, if you ask `sgpt` to update your system, it will return a command based on your OS. Here's an example using macOS:
 ```shell
 sgpt -s "update my system"
 # -> sudo softwareupdate -i -a
+# -> [E]xecute, [D]escribe, [A]bort: e
+...
 ```
 The same prompt, when used on Ubuntu, will generate a different suggestion:
 ```shell
 sgpt -s "update my system"
 # -> sudo apt update && sudo apt upgrade -y
+# -> [E]xecute, [D]escribe, [A]bort: e
+...
+```
+We can ask GPT to describe suggested shell command, it will provide a short description of what the command does:
+```shell
+sgpt -s "show all txt files in current folder"
+# -> ls *.txt
+# -> [E]xecute, [D]escribe, [A]bort: d
+# -> List all files with .txt extension in current directory
+# -> [E]xecute, [D]escribe, [A]bort: e
+...
 ```
 Let's try some docker containers:
 ```shell
 sgpt -s "start nginx using docker, forward 443 and 80 port, mount current folder with index.html"
 # -> docker run -d -p 443:443 -p 80:80 -v $(pwd):/usr/share/nginx/html nginx
-# -> Execute shell command? [y/N]: y
-# ...
+# -> [E]xecute, [D]escribe, [A]bort: e
+...
 ```
 We can still use pipes to pass input to `sgpt` and get shell commands as output:
 ```shell
@@ -76,8 +89,8 @@ ls
 # -> 1.mp4 2.mp4 3.mp4
 sgpt -s "using ffmpeg combine multiple videos into one without audio. Video file names: $(ls -m)"
 # -> ffmpeg -i 1.mp4 -i 2.mp4 -i 3.mp4 -filter_complex "[0:v] [1:v] [2:v] concat=n=3:v=1 [v]" -map "[v]" out.mp4
-# -> Execute shell command? [y/N]: y
-# ...
+# -> [E]xecute, [D]escribe, [A]bort: e
+...
 ```
 ### Generating code
 With `--code` parameters we can query only code as output, for example:
@@ -200,7 +213,7 @@ ls
 ls -lh
 >>> Sort them by file sizes
 ls -lhS
->>> e (enter just e to execute commands)
+>>> e (enter just e to execute commands, or d to describe them)
 ...
 ```
 Example of using REPL mode to generate code:
@@ -308,6 +321,7 @@ Switch `SYSTEM_ROLES` to force use [system roles](https://help.openai.com/en/art
 ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Assistance Options ────────────────────────────────────────────────────────────────────────────────────────╮
 │ --shell  -s                 Generate and execute shell commands.                                            │
+│ --describe-shell  -d        Describe a shell command.                                                       │
 │ --code       --no-code      Generate only code. [default: no-code]                                          │
 ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Chat Options ──────────────────────────────────────────────────────────────────────────────────────────────╮

--- a/sgpt/__init__.py
+++ b/sgpt/__init__.py
@@ -1,4 +1,4 @@
 from .app import main as main
 from .app import entry_point as cli  # noqa: F401
 
-__version__ = "0.9.0"
+__version__ = "0.9.1"

--- a/sgpt/handlers/chat_handler.py
+++ b/sgpt/handlers/chat_handler.py
@@ -5,7 +5,6 @@ from typing import Any, Callable, Dict, Generator, List, Optional
 import typer
 from click import BadArgumentUsage
 
-from ..client import OpenAIClient
 from ..config import cfg
 from ..role import SystemRole
 from .handler import Handler
@@ -91,15 +90,9 @@ class ChatSession:
 class ChatHandler(Handler):
     chat_session = ChatSession(CHAT_CACHE_LENGTH, CHAT_CACHE_PATH)
 
-    def __init__(
-        self,
-        client: OpenAIClient,
-        chat_id: str,
-        role: SystemRole,
-    ) -> None:
-        super().__init__(client, role)
+    def __init__(self, chat_id: str, role: SystemRole) -> None:
+        super().__init__(role)
         self.chat_id = chat_id
-        self.client = client
         self.role = role
 
         if chat_id == "temp":

--- a/sgpt/handlers/default_handler.py
+++ b/sgpt/handlers/default_handler.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 from typing import Dict, List
 
-from ..client import OpenAIClient
 from ..config import cfg
 from ..role import SystemRole
 from .handler import Handler
@@ -11,13 +10,8 @@ CHAT_CACHE_PATH = Path(cfg.get("CHAT_CACHE_PATH"))
 
 
 class DefaultHandler(Handler):
-    def __init__(
-        self,
-        client: OpenAIClient,
-        role: SystemRole,
-    ) -> None:
-        super().__init__(client, role)
-        self.client = client
+    def __init__(self, role: SystemRole) -> None:
+        super().__init__(role)
         self.role = role
 
     def make_prompt(self, prompt: str) -> str:

--- a/sgpt/handlers/handler.py
+++ b/sgpt/handlers/handler.py
@@ -8,8 +8,10 @@ from ..role import SystemRole
 
 
 class Handler:
-    def __init__(self, client: OpenAIClient, role: SystemRole) -> None:
-        self.client = client
+    def __init__(self, role: SystemRole) -> None:
+        self.client = OpenAIClient(
+            cfg.get("OPENAI_API_HOST"), cfg.get("OPENAI_API_KEY")
+        )
         self.role = role
         self.color = cfg.get("DEFAULT_COLOR")
 

--- a/sgpt/handlers/repl_handler.py
+++ b/sgpt/handlers/repl_handler.py
@@ -4,15 +4,15 @@ import typer
 from rich import print as rich_print
 from rich.rule import Rule
 
-from ..client import OpenAIClient
 from ..role import DefaultRoles, SystemRole
 from ..utils import run_command
 from .chat_handler import ChatHandler
+from .default_handler import DefaultHandler
 
 
 class ReplHandler(ChatHandler):
-    def __init__(self, client: OpenAIClient, chat_id: str, role: SystemRole) -> None:
-        super().__init__(client, chat_id, role)
+    def __init__(self, chat_id: str, role: SystemRole) -> None:
+        super().__init__(chat_id, role)
 
     def handle(self, prompt: str, **kwargs: Any) -> None:  # type: ignore
         if self.initiated:
@@ -23,25 +23,32 @@ class ReplHandler(ChatHandler):
         info_message = (
             "Entering REPL mode, press Ctrl+C to exit."
             if not self.role.name == DefaultRoles.SHELL.value
-            else "Entering shell REPL mode, type [e] to execute commands or press Ctrl+C to exit."
+            else (
+                "Entering shell REPL mode, type [e] to execute commands "
+                "or [d] to describe the commands, press Ctrl+C to exit."
+            )
         )
         typer.secho(info_message, fg="yellow")
 
-        if not prompt:
-            prompt = typer.prompt(">>>", prompt_suffix=" ")
-        else:
-            typer.echo(f">>> {prompt}")
-
+        full_completion = ""
         while True:
-            full_completion = super().handle(prompt, **kwargs)
+            # Infinite loop until user exits with Ctrl+C.
             prompt = typer.prompt(">>>", prompt_suffix=" ")
             if prompt == "exit()":
                 # This is also useful during tests.
                 raise typer.Exit()
-            if self.role.name == DefaultRoles.SHELL.value:
-                if prompt == "e":
-                    typer.echo()
-                    run_command(full_completion)
-                    typer.echo()
-                    rich_print(Rule(style="bold magenta"))
-                    prompt = typer.prompt(">>> ", prompt_suffix=" ")
+            if self.role.name == DefaultRoles.SHELL.value and prompt == "e":
+                typer.echo()
+                run_command(full_completion)
+                typer.echo()
+                rich_print(Rule(style="bold magenta"))
+            elif self.role.name == DefaultRoles.SHELL.value and prompt == "d":
+                DefaultHandler(DefaultRoles.DESCRIBE_SHELL.get_role()).handle(
+                    full_completion,
+                    model=kwargs.get("model"),
+                    temperature=kwargs.get("temperature"),
+                    top_probability=kwargs.get("top_probability"),
+                    caching=kwargs.get("caching"),
+                )
+            else:
+                full_completion = super().handle(prompt, **kwargs)

--- a/sgpt/role.py
+++ b/sgpt/role.py
@@ -194,7 +194,7 @@ class DefaultRoles(Enum):
     CODE = "code"
 
     @classmethod
-    def get(cls, shell: bool, describe_shell: bool, code: bool) -> SystemRole:
+    def check_get(cls, shell: bool, describe_shell: bool, code: bool) -> SystemRole:
         if shell:
             return SystemRole.get(DefaultRoles.SHELL.value)
         if describe_shell:
@@ -202,6 +202,9 @@ class DefaultRoles(Enum):
         if code:
             return SystemRole.get(DefaultRoles.CODE.value)
         return SystemRole.get(DefaultRoles.DEFAULT.value)
+
+    def get_role(self) -> SystemRole:
+        return SystemRole.get(self.value)
 
 
 SystemRole.create_defaults()


### PR DESCRIPTION
* Add a prompt option to describe shell command when executing it with `--shell` flag.
* Minor code optiomization and bug fixies.

To test it run:
```shell
sgpt -s "what is in current folder"
# -> [E]xecute, [D]escribe, [A]bort: d
# -> List the files and directories in the current directory.
# -> [E]xecute, [D]escribe, [A]bort: e
...
```
Same logic works in REPL mode.
