### PR TITLE
prevent AttributeError in non-interactive shells

### DIFF
--- a/sgpt/app.py
+++ b/sgpt/app.py
@@ -116,7 +116,11 @@ def main(
         rich_help_panel="Role Options",
     ),
 ) -> None:
-    stdin_passed = not sys.stdin.isatty()
+    if sys.stdin is not None:
+        stdin_passed = not sys.stdin.isatty()
+    else:
+        stdin_passed = False
+
 
     if stdin_passed and not repl:
         prompt = f"{sys.stdin.read()}\n\n{prompt or ''}"


### PR DESCRIPTION
This PR addresses a case in sgpt/app.py where sgpt would throw an AttributeError if sys.stdin is None.
This allows sgpt  to run in environments where there's no interactive shell, such as in a background process or from a cron job.
This change should prevent the AttributeError from occurring in these scenarios.
