### PR TITLE
Model endpoint compatibility

### DIFF
--- a/sgpt/config.py
+++ b/sgpt/config.py
@@ -23,7 +23,7 @@ DEFAULT_CONFIG = {
     "CHAT_CACHE_LENGTH": int(os.getenv("CHAT_CACHE_LENGTH", "100")),
     "CACHE_LENGTH": int(os.getenv("CHAT_CACHE_LENGTH", "100")),
     "REQUEST_TIMEOUT": int(os.getenv("REQUEST_TIMEOUT", "60")),
-    "DEFAULT_MODEL": os.getenv("DEFAULT_MODEL", ModelOptions.GPT3.value),
+    "DEFAULT_MODEL": os.getenv("DEFAULT_MODEL", ModelOptions.GPT35TURBO.value),
     "OPENAI_API_HOST": os.getenv("OPENAI_API_HOST", "https://api.openai.com"),
     "DEFAULT_COLOR": os.getenv("DEFAULT_COLOR", "magenta"),
     "ROLE_STORAGE_PATH": os.getenv("ROLE_STORAGE_PATH", str(ROLE_STORAGE_PATH)),

--- a/sgpt/utils.py
+++ b/sgpt/utils.py
@@ -10,9 +10,16 @@ from click import BadParameter
 
 
 class ModelOptions(str, Enum):
-    GPT3 = "gpt-3.5-turbo"
-    GPT4 = "gpt-4"
-    GPT4_32K = "gpt-4-32k"
+    """
+    Model endpoint compatibility
+    https://platform.openai.com/docs/models/model-endpoint-compatibility
+    """
+    GPT4 = 'gpt-4'
+    GPT40314 = 'gpt-4-0314'
+    GPT432k = 'gpt-4-32k'
+    GPT432k0314 = 'gpt-4-32k-0314'
+    GPT35TURBO = 'gpt-3.5-turbo'
+    GPT35TURBO0301 = 'gpt-3.5-turbo-0301'
 
 
 def get_edited_prompt() -> str:

--- a/sgpt/utils.py
+++ b/sgpt/utils.py
@@ -14,17 +14,18 @@ class ModelOptions(str, Enum):
     Model endpoint compatibility
     https://platform.openai.com/docs/models/model-endpoint-compatibility
     """
-    GPT4 = 'gpt-4'
-    GPT40314 = 'gpt-4-0314' # discontinued 2023-09-13
-    GPT40613 = 'gpt-4-0613'
-    GPT432k = 'gpt-4-32k'
-    GPT432k0314 = 'gpt-4-32k-0314' # discontinued 2023-09-13
-    GPT432k0613 = 'gpt-4-32k-0613'
-    GPT35TURBO = 'gpt-3.5-turbo'
-    GPT35TURBO16K = 'gpt-3.5-turbo-16k'
-    GPT35TURBO16K0613 = 'gpt-3.5-turbo-16k-0613'
-    GPT35TURBO0301 = 'gpt-3.5-turbo-0301'  # discontinued 2023-09-13
-    GPT35TURBO0613 = 'gpt-3.5-turbo-0613'
+
+    GPT4 = "gpt-4"
+    GPT40314 = "gpt-4-0314"  # discontinued 2023-09-13
+    GPT40613 = "gpt-4-0613"
+    GPT432k = "gpt-4-32k"
+    GPT432k0314 = "gpt-4-32k-0314"  # discontinued 2023-09-13
+    GPT432k0613 = "gpt-4-32k-0613"
+    GPT35TURBO = "gpt-3.5-turbo"
+    GPT35TURBO16K = "gpt-3.5-turbo-16k"
+    GPT35TURBO16K0613 = "gpt-3.5-turbo-16k-0613"
+    GPT35TURBO0301 = "gpt-3.5-turbo-0301"  # discontinued 2023-09-13
+    GPT35TURBO0613 = "gpt-3.5-turbo-0613"
 
 
 def get_edited_prompt() -> str:

--- a/sgpt/utils.py
+++ b/sgpt/utils.py
@@ -15,11 +15,16 @@ class ModelOptions(str, Enum):
     https://platform.openai.com/docs/models/model-endpoint-compatibility
     """
     GPT4 = 'gpt-4'
-    GPT40314 = 'gpt-4-0314'
+    GPT40314 = 'gpt-4-0314' # discontinued 2023-09-13
+    GPT40613 = 'gpt-4-0613'
     GPT432k = 'gpt-4-32k'
-    GPT432k0314 = 'gpt-4-32k-0314'
+    GPT432k0314 = 'gpt-4-32k-0314' # discontinued 2023-09-13
+    GPT432k0613 = 'gpt-4-32k-0613'
     GPT35TURBO = 'gpt-3.5-turbo'
-    GPT35TURBO0301 = 'gpt-3.5-turbo-0301'
+    GPT35TURBO16K = 'gpt-3.5-turbo-16k'
+    GPT35TURBO16K0613 = 'gpt-3.5-turbo-16k-0613'
+    GPT35TURBO0301 = 'gpt-3.5-turbo-0301'  # discontinued 2023-09-13
+    GPT35TURBO0613 = 'gpt-3.5-turbo-0613'
 
 
 def get_edited_prompt() -> str:


### PR DESCRIPTION
## Summary

Adding models found in [OpenAI docs for model compatibility](https://platform.openai.com/docs/models/model-endpoint-compatibility). I found that the responses have started to drift in their length, so I'd like to set the frozen version of `gpt-3.5-turbo` as my default (`gpt-3.5-turbo-0301`)

## Testing

### Setup

```bash
conda create -n test python=3.10 -y
conda activate test
python -m pip install -e ."[dev,test]"
python -m pytest
```

### Results

```bash
(test) ➜  shell_gpt git:(adding-models) ✗ python -m pytest                                     0:03:08
========================================= test session starts =========================================
platform darwin -- Python 3.10.11, pytest-7.3.1, pluggy-1.0.0
rootdir: /Users/will-wright-eng/shell_gpt
plugins: requests-mock-1.10.0
collected 24 items

tests/test_integration.py ......................                                                [ 91%]
tests/test_unit.py ..                                                                           [100%]

==================================== 24 passed in 87.27s (0:01:27) ====================================
```