### PR TITLE
added a check for empty var

### DIFF
--- a/simple_bash.sh
+++ b/simple_bash.sh
@@ -1,7 +1,9 @@
 # Shell-GPT integration BASH v0.1
 _sgpt_bash() {
-    READLINE_LINE=$(sgpt --shell <<< "$READLINE_LINE")
+if [[ -n "$READLINE_LINE" ]]; then
+	READLINE_LINE=$(sgpt --shell <<< "$READLINE_LINE")
     READLINE_POINT=${#READLINE_LINE}
+fi
 }
 bind -x '"\C-l": _sgpt_bash'
 # Shell-GPT integration BASH v0.1

--- a/simple_zsh.sh
+++ b/simple_zsh.sh
@@ -1,10 +1,12 @@
 # Shell-GPT integration ZSH v0.1
 _sgpt_zsh() {
+if [[ -n "$BUFFER"]]; then
     _sgpt_prev_cmd=$BUFFER
     BUFFER+="⌛"
     zle -I && zle redisplay
     BUFFER=$(sgpt --shell <<< "$_sgpt_prev_cmd")
     zle end-of-line
+fi
 }
 zle -N _sgpt_zsh
 bindkey ^l _sgpt_zsh


### PR DESCRIPTION
Shell integrations behaves weird if the command line is empty. 
Added a basic check for bash to not execute with empty command line.