### PR TITLE
added gpt-3.5-turbo-16k model

### DIFF
--- a/sgpt/utils.py
+++ b/sgpt/utils.py
@@ -11,6 +11,7 @@ from click import BadParameter
 
 class ModelOptions(str, Enum):
     GPT3 = "gpt-3.5-turbo"
+    GPT3_16k = "gpt-3.5-turbo-16k"
     GPT4 = "gpt-4"
     GPT4_32K = "gpt-4-32k"
 


### PR DESCRIPTION
# Description
This is a simple pull request that modifies the `utils.py` file in the `sgpt` directory. The changes add a new option to the "ModelOptions" class called `GPT3_16k`, which has a value of `gpt-3.5-turbo-16k` 

This in light of the [new model that came out of OpenAI new just today.](https://openai.com/blog/function-calling-and-other-api-updates)

Let me know if there are any other issues with this.