### PR TITLE
Properly ignore SSE comments

### DIFF
--- a/sgpt/client.py
+++ b/sgpt/client.py
@@ -66,6 +66,8 @@ class OpenAIClient:
             yield data["choices"][0]["message"]["content"]  # type: ignore
             return
         for line in response.iter_lines():
+            if line.startswith(b":"): # SSE comment
+                continue
             data = line.lstrip(b"data: ").decode("utf-8")
             if data == "[DONE]":  # type: ignore
                 break


### PR DESCRIPTION
This change makes the client not choke on [SSE comments](https://html.spec.whatwg.org/multipage/server-sent-events.html#authoring-notes).
Comments are allowed and relevant for API proxies such as openrouter.ai who throw in `: OPENROUTER PROCESSING` and such (see https://openrouter.ai/docs#format)