### PR TITLE
Make optional HTTP-referer configurable

### DIFF
--- a/sgpt/client.py
+++ b/sgpt/client.py
@@ -16,9 +16,10 @@ DISABLE_STREAMING = str(cfg.get("DISABLE_STREAMING"))
 class OpenAIClient:
     cache = Cache(CACHE_LENGTH, CACHE_PATH)
 
-    def __init__(self, api_host: str, api_key: str) -> None:
+    def __init__(self, api_host: str, api_key: str, referer: str) -> None:
         self.__api_key = api_key
         self.api_host = api_host
+        self.referer = referer
 
     @cache
     def _request(
@@ -53,6 +54,7 @@ class OpenAIClient:
             headers={
                 "Content-Type": "application/json",
                 "Authorization": f"Bearer {self.__api_key}",
+                **({"Http-Referer": self.referer} if self.referer != "<none>" else {}),
             },
             json=data,
             timeout=REQUEST_TIMEOUT,

--- a/sgpt/config.py
+++ b/sgpt/config.py
@@ -23,6 +23,7 @@ DEFAULT_CONFIG = {
     "REQUEST_TIMEOUT": int(os.getenv("REQUEST_TIMEOUT", "60")),
     "DEFAULT_MODEL": os.getenv("DEFAULT_MODEL", "gpt-3.5-turbo"),
     "OPENAI_API_HOST": os.getenv("OPENAI_API_HOST", "https://api.openai.com"),
+    "DEFAULT_REFERER": os.getenv("DEFAULT_REFERER", "<none>"),
     "DEFAULT_COLOR": os.getenv("DEFAULT_COLOR", "magenta"),
     "ROLE_STORAGE_PATH": os.getenv("ROLE_STORAGE_PATH", str(ROLE_STORAGE_PATH)),
     "SYSTEM_ROLES": os.getenv("SYSTEM_ROLES", "false"),

--- a/sgpt/handlers/handler.py
+++ b/sgpt/handlers/handler.py
@@ -10,7 +10,8 @@ from ..role import SystemRole
 class Handler:
     def __init__(self, role: SystemRole) -> None:
         self.client = OpenAIClient(
-            cfg.get("OPENAI_API_HOST"), cfg.get("OPENAI_API_KEY")
+            cfg.get("OPENAI_API_HOST"), cfg.get("OPENAI_API_KEY"),
+            cfg.get("DEFAULT_REFERER")
         )
         self.role = role
         self.color = cfg.get("DEFAULT_COLOR")


### PR DESCRIPTION
This makes the HTTP Referrer configurable, which is required for requests to make `OPENAI_API_HOST=https://openrouter.ai/api` work (and then together with #358 it just works :tm:, with all their models). Spelling is consistent with header name, but could also be "proper" instead.

This implementation is a bit awkward and uses a special string "<none>" for unset, because Config.get() requires truthy values, so it can't just be left empty. But at least this way it's very unlikely to break anything for anyone.