### PR TITLE
Azure OpenAI Service

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ You'll need an OpenAI API key, you can generate one [here](https://beta.openai.c
 
 If the`$OPENAI_API_KEY` environment variable is set it will be used, otherwise, you will be prompted for your key which will then be stored in `~/.config/shell_gpt/.sgptrc`.
 
+This tool also supports [Azure OpenAI service](https://azure.microsoft.com/en-us/products/ai-services/openai-service). In order to use it you'll need to set additional environment variables:
+
+`$USE_AZURE_OPENAI=true` to use different APIs endpoint;
+`$AZURE_OPENAI_DEPLOYMENT_NAME` an Azure OpenAI model deployment name, you can follow the  [Microsoft documentation](https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/create-resource) to get one.
+
 ## Usage
 `sgpt` has a variety of use cases, including simple queries, shell queries, and code queries.
 ### Simple queries

--- a/sgpt/client.py
+++ b/sgpt/client.py
@@ -102,3 +102,94 @@ class OpenAIClient:
             top_probability,
             caching=caching,
         )
+
+class AzureOpenAIClient:
+    cache = Cache(CACHE_LENGTH, CACHE_PATH)
+
+    def __init__(self, api_host: str, api_key: str, deployment_name: str) -> None:
+        self.__api_key = api_key
+        self.api_host = api_host
+        self.deployment_name = deployment_name
+
+    @cache
+    def _request(
+        self,
+        messages: List[Dict[str, str]],
+        model: str = "gpt-3.5-turbo",
+        temperature: float = 1,
+        top_probability: float = 1,
+    ) -> Generator[str, None, None]:
+        """
+        Make request to OpenAI API, read more:
+        https://platform.openai.com/docs/api-reference/chat
+
+        :param messages: List of messages {"role": user or assistant, "content": message_string}
+        :param model: String gpt-3.5-turbo or gpt-3.5-turbo-0301
+        :param temperature: Float in 0.0 - 2.0 range.
+        :param top_probability: Float in 0.0 - 1.0 range.
+        :return: Response body JSON.
+        """
+        stream = DISABLE_STREAMING == "false"
+        data = {
+            "messages": messages,
+            "model": model,
+            "temperature": temperature,
+            "top_p": top_probability,
+            "stream": stream,
+        }
+        endpoint = f"{self.api_host}/openai/deployments/{self.deployment_name}/chat/completions?api-version=2023-05-15"
+        response = requests.post(
+            endpoint,
+            # Hide API key from Rich traceback.
+            headers={
+                "Content-Type": "application/json",                
+                "api-key": f"{self.__api_key}"
+            },
+            json=data,
+            timeout=REQUEST_TIMEOUT,
+            stream=stream,
+        )
+        response.raise_for_status()
+        # TODO: Optimise.
+        # https://github.com/openai/openai-python/blob/237448dc072a2c062698da3f9f512fae38300c1c/openai/api_requestor.py#L98
+        if not stream:
+            data = response.json()
+            yield data["choices"][0]["message"]["content"]  # type: ignore
+            return
+        for line in response.iter_lines():
+            data = line.lstrip(b"data: ").decode("utf-8")
+            if data == "[DONE]":  # type: ignore
+                break
+            if not data:
+                continue
+            data = json.loads(data)  # type: ignore
+            delta = data["choices"][0]["delta"]  # type: ignore
+            if "content" not in delta:
+                continue
+            yield delta["content"]
+
+    def get_completion(
+        self,
+        messages: List[Dict[str, str]],
+        model: str = "gpt-3.5-turbo",
+        temperature: float = 1,
+        top_probability: float = 1,
+        caching: bool = True,
+    ) -> Generator[str, None, None]:
+        """
+        Generates single completion for prompt (message).
+
+        :param messages: List of dict with messages and roles.
+        :param model: String gpt-3.5-turbo or gpt-3.5-turbo-0301.
+        :param temperature: Float in 0.0 - 1.0 range.
+        :param top_probability: Float in 0.0 - 1.0 range.
+        :param caching: Boolean value to enable/disable caching.
+        :return: String generated completion.
+        """
+        yield from self._request(
+            messages,
+            model,
+            temperature,
+            top_probability,
+            caching=caching,
+        )

--- a/sgpt/config.py
+++ b/sgpt/config.py
@@ -22,6 +22,8 @@ DEFAULT_CONFIG = {
     "CACHE_LENGTH": int(os.getenv("CHAT_CACHE_LENGTH", "100")),
     "REQUEST_TIMEOUT": int(os.getenv("REQUEST_TIMEOUT", "60")),
     "DEFAULT_MODEL": os.getenv("DEFAULT_MODEL", "gpt-3.5-turbo"),
+    "USE_AZURE_OPENAI": os.getenv("USE_AZURE_OPENAI", "false"),
+    "AZURE_OPENAI_DEPLOYMENT_NAME": os.getenv("AZURE_OPENAI_DEPLOYMENT_NAME", ""),
     "OPENAI_API_HOST": os.getenv("OPENAI_API_HOST", "https://api.openai.com"),
     "DEFAULT_COLOR": os.getenv("DEFAULT_COLOR", "magenta"),
     "ROLE_STORAGE_PATH": os.getenv("ROLE_STORAGE_PATH", str(ROLE_STORAGE_PATH)),

--- a/sgpt/handlers/handler.py
+++ b/sgpt/handlers/handler.py
@@ -3,15 +3,21 @@ from typing import Any, Dict, Generator, List
 import typer
 
 from ..client import OpenAIClient
+from ..client import AzureOpenAIClient
 from ..config import cfg
 from ..role import SystemRole
 
 
 class Handler:
-    def __init__(self, role: SystemRole) -> None:
-        self.client = OpenAIClient(
-            cfg.get("OPENAI_API_HOST"), cfg.get("OPENAI_API_KEY")
-        )
+    def __init__(self, role: SystemRole) -> None:       
+        if cfg.get("USE_AZURE_OPENAI") == "true":
+            self.client = AzureOpenAIClient(
+                cfg.get("OPENAI_API_HOST"), cfg.get("OPENAI_API_KEY"), cfg.get("AZURE_OPENAI_DEPLOYMENT_NAME")
+            )
+        else:
+            self.client = OpenAIClient(
+                cfg.get("OPENAI_API_HOST"), cfg.get("OPENAI_API_KEY")
+            )
         self.role = role
         self.color = cfg.get("DEFAULT_COLOR")
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -353,7 +353,11 @@ class TestShellGpt(TestCase):
         # assert "command not found" not in result.stdout
         # assert "hello world" in stdout.split("\n")[-1]
 
-    @patch("sgpt.client.OpenAIClient.get_completion")
+    if (cfg.get("USE_AZURE_OPENAI") == "false"):
+        patch_string = "sgpt.client.OpenAIClient.get_completion"
+    else:
+        patch_string = "sgpt.client.AzureOpenAIClient.get_completion"
+    @patch(patch_string)
     def test_model_option(self, mocked_get_completion):
         dict_arguments = {
             "prompt": "What is the capital of the Czech Republic?",
@@ -368,7 +372,7 @@ class TestShellGpt(TestCase):
             caching=False,
         )
         assert result.exit_code == 0
-
+    
     def test_color_output(self):
         color = cfg.get("DEFAULT_COLOR")
         role = SystemRole.get("default")


### PR DESCRIPTION
Hi team, I've added the support to Azure OpenAI services by simply introducing a new client class (that now is essentially the same, but with different endpoint and auth header). The handler will use the right class by evaluating a new param in the cfg kv collection.