### PR TITLE
add syntax highlighting via themeing

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,8 @@ SYSTEM_ROLES=false
 DEFAULT_EXECUTE_SHELL_CMD=false
 # Disable streaming of responses
 DISABLE_STREAMING=false
+# The pygment theme to use for syntax highlighting
+CODE_THEME=one-dark
 ```
 Possible options for `DEFAULT_COLOR`: black, red, green, yellow, blue, magenta, cyan, white, bright_black, bright_red, bright_green, bright_yellow, bright_blue, bright_magenta, bright_cyan, bright_white.
 

--- a/sgpt/config.py
+++ b/sgpt/config.py
@@ -28,7 +28,7 @@ DEFAULT_CONFIG = {
     "SYSTEM_ROLES": os.getenv("SYSTEM_ROLES", "false"),
     "DEFAULT_EXECUTE_SHELL_CMD": os.getenv("DEFAULT_EXECUTE_SHELL_CMD", "false"),
     "DISABLE_STREAMING": os.getenv("DISABLE_STREAMING", "false"),
-    "CODE_THEME": os.getenv("CODE_THEME", "one-dark"),
+    "CODE_THEME": os.getenv("CODE_THEME", "one-dark")
     # New features might add their own config variables here.
 }
 

--- a/sgpt/config.py
+++ b/sgpt/config.py
@@ -27,7 +27,8 @@ DEFAULT_CONFIG = {
     "ROLE_STORAGE_PATH": os.getenv("ROLE_STORAGE_PATH", str(ROLE_STORAGE_PATH)),
     "SYSTEM_ROLES": os.getenv("SYSTEM_ROLES", "false"),
     "DEFAULT_EXECUTE_SHELL_CMD": os.getenv("DEFAULT_EXECUTE_SHELL_CMD", "false"),
-    "DISABLE_STREAMING": os.getenv("DISABLE_STREAMING", "false")
+    "DISABLE_STREAMING": os.getenv("DISABLE_STREAMING", "false"),
+    "CODE_THEME": os.getenv("CODE_THEME", "one-dark"),
     # New features might add their own config variables here.
 }
 

--- a/sgpt/handlers/handler.py
+++ b/sgpt/handlers/handler.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict, List, Generator
+from typing import Any, Dict, Generator, List
+
 from rich.console import Console
 from rich.live import Live
 from rich.markdown import Markdown
@@ -30,7 +31,10 @@ class Handler:
         messages = self.make_messages(self.make_prompt(prompt))
         full_completion = ""
         with Live(Markdown('', code_theme=self.theme), console=self.console) as live:
+            stream = cfg.get("DISABLE_STREAMING") == "false"
+            if not stream:
+                live.update(Markdown("Loading...\r", code_theme=self.theme), refresh=True)
             for word in self.get_completion(messages=messages, **kwargs):
                 full_completion += word
-                live.update(Markdown(full_completion, code_theme=self.theme), refresh=True)
+                live.update(Markdown(full_completion, code_theme=self.theme), refresh=True if not stream else False)
         return full_completion

--- a/sgpt/handlers/handler.py
+++ b/sgpt/handlers/handler.py
@@ -14,6 +14,7 @@ class Handler:
         )
         self.role = role
         self.color = cfg.get("DEFAULT_COLOR")
+        self.theme = cfg.get("CODE_THEME")
         self.console = Console()
 
     def make_prompt(self, prompt: str) -> str:
@@ -28,9 +29,8 @@ class Handler:
     def handle(self, prompt: str, **kwargs: Any) -> str:
         messages = self.make_messages(self.make_prompt(prompt))
         full_completion = ""
-        # Use Live display for streaming
-        with Live(Markdown(''), console=self.console) as live:
+        with Live(Markdown('', code_theme=self.theme), console=self.console) as live:
             for word in self.get_completion(messages=messages, **kwargs):
                 full_completion += word
-                live.update(Markdown(full_completion, code_theme=cfg.get("THEME")), refresh=True)
+                live.update(Markdown(full_completion, code_theme=self.theme), refresh=True)
         return full_completion


### PR DESCRIPTION
Related to #333, this approach enables syntax highlighting, including for streaming chats

![sgpt-theme](https://github.com/TheR1D/shell_gpt/assets/18407013/59ca79a9-d1a8-4fc7-b8d3-1d9bda65076e)
