### PR TITLE
fix: trim markdown style code annotations from shell output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+__pycache__/

--- a/sgpt/handlers/handler.py
+++ b/sgpt/handlers/handler.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, Generator, List
 
 import typer
+import re
 
 from ..client import OpenAIClient
 from ..config import cfg
@@ -31,6 +32,10 @@ class Handler:
         if not stream:
             typer.echo("Loading...\r", nl=False)
         for word in self.get_completion(messages=messages, **kwargs):
+            if self.role.name == "shell":
+                # take out code blocks if any
+                word = re.sub(r"```\w+\n", "", word)
+                word = re.sub(r"\n```", "", word)
             typer.secho(word, fg=self.color, bold=True, nl=False)
             full_completion += word
         typer.echo("\033[K" if not stream else "")  # Overwrite "loading..."


### PR DESCRIPTION
- add gitignore
- take out any markdown style code blocks covering shell output

With some more recent models whenever I use the shell output format the response includes something like this and we take those out here. We might be able to achieve this with better `role` descriptions aka prompts but I couldn't get that to reliably work and this is easier to reason about.

```
\```zsh
cowsay hi
\```
```


Tested on the following model

```

MODEL | DESCRIPTION | CONTEXT WINDOW | TRAINING DATA
-- | -- | -- | --
gpt-4-1106-preview | GPT-4 TurboNewThe latest GPT-4 model with improved instruction following, JSON mode, reproducible outputs, parallel function calling, and more. Returns a maximum of 4,096 output tokens. This preview model is not yet suited for production traffic. Learn more. | 128,000 tokens | Up to Apr 2023

MODEL	DESCRIPTION	CONTEXT WINDOW	TRAINING DATA
gpt-4-1106-preview	GPT-4 TurboNew
The latest GPT-4 model with improved instruction following, JSON mode, reproducible outputs, parallel function calling, and more. Returns a maximum of 4,096 output tokens. This preview model is not yet suited for production traffic. [Learn more](https://openai.com/blog/new-models-and-developer-products-announced-at-devday).	128,000 tokens	Up to Apr 2023
```