### PR TITLE
Set Home Directory for 'app' User in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY . /app
 
 RUN pip install --no-cache --upgrade pip \
  && pip install --no-cache /app \
- && addgroup --system app && adduser --system --group app \
+ && addgroup --system app && adduser --system --group --home /home/app app \
  && mkdir -p /tmp/shell_gpt \
  && chown -R app:app /tmp/shell_gpt
 


### PR DESCRIPTION
Set Home Directory for 'app' User in Dockerfile: 

- fixes issue related to nonexistent default home directory, addressing permission errors during container runtime.


```docker run --rm --env OPENAI_API_KEY="api key here" --volume gpt-cache:/tmp/shell_gpt sgpt
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/pathlib.py", line 1312, in mkdir
    os.mkdir(self, mode)
FileNotFoundError: [Errno 2] No such file or directory: '/nonexistent/.config/shell_gpt'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.12/pathlib.py", line 1312, in mkdir
    os.mkdir(self, mode)
FileNotFoundError: [Errno 2] No such file or directory: '/nonexistent/.config'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/bin/sgpt", line 5, in <module>
    from sgpt import cli
  File "/usr/local/lib/python3.12/site-packages/sgpt/__init__.py", line 1, in <module>
    from .app import main as main
  File "/usr/local/lib/python3.12/site-packages/sgpt/app.py", line 9, in <module>
    from sgpt.config import cfg
  File "/usr/local/lib/python3.12/site-packages/sgpt/config.py", line 83, in <module>
    cfg = Config(SHELL_GPT_CONFIG_PATH, **DEFAULT_CONFIG)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/sgpt/config.py", line 49, in __init__
    config_path.parent.mkdir(parents=True, exist_ok=True)
  File "/usr/local/lib/python3.12/pathlib.py", line 1316, in mkdir
    self.parent.mkdir(parents=True, exist_ok=True)
  File "/usr/local/lib/python3.12/pathlib.py", line 1316, in mkdir
    self.parent.mkdir(parents=True, exist_ok=True)
  File "/usr/local/lib/python3.12/pathlib.py", line 1312, in mkdir
    os.mkdir(self, mode)
PermissionError: [Errno 13] Permission denied: '/nonexistent'
```