### PR TITLE
Empty chunk choices

### DIFF
--- a/sgpt/handlers/handler.py
+++ b/sgpt/handlers/handler.py
@@ -81,6 +81,9 @@ class Handler:
             functions=functions,  # type: ignore
             stream=True,
         ):
+            # Some APIs return an empty list of choices
+            if not chunk.choices:
+                continue
             delta = chunk.choices[0].delta  # type: ignore
             if delta.function_call:
                 if delta.function_call.name:

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -8,7 +8,7 @@ from sgpt import config, main
 from sgpt.__version__ import __version__
 from sgpt.role import DefaultRoles, SystemRole
 
-from .utils import app, cmd_args, comp_args, comp_chunks, runner
+from .utils import app, cmd_args, comp_args, comp_chunks, empty_chunk, runner
 
 role = SystemRole.get(DefaultRoles.DEFAULT.value)
 cfg = config.cfg
@@ -186,3 +186,15 @@ def test_version(completion):
 
     completion.assert_not_called()
     assert __version__ in result.stdout
+
+
+@patch("openai.resources.chat.Completions.create")
+def test_empty_chunk_handling(completion):
+    completion.return_value = [empty_chunk]
+
+    args = {"prompt": "capital of liechtenstein?"}
+    result = runner.invoke(app, cmd_args(**args))
+
+    completion.assert_called_once_with(**comp_args(role, **args))
+    assert result.exit_code == 0
+    assert not result.stdout.strip()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -13,6 +13,14 @@ runner = CliRunner()
 app = typer.Typer()
 app.command()(main)
 
+empty_chunk = ChatCompletionChunk(
+    id="foo",
+    model=cfg.get("DEFAULT_MODEL"),
+    object="chat.completion.chunk",
+    choices=[],
+    created=int(datetime.datetime.now().timestamp()),
+)
+
 
 def comp_chunks(tokens_string):
     return [


### PR DESCRIPTION
Some OpenAI "compatible" APIs (e.g. https://lepton.ai) return a chunk with an empty list of choices at the end of their responses.

Currently this causes an error with shell-gpt as this case is not handled, which this PR fixes.
