### PR TITLE
Move api_key from additional kwargs to OpenAI instantiation

### DIFF
--- a/sgpt/handlers/handler.py
+++ b/sgpt/handlers/handler.py
@@ -13,7 +13,6 @@ base_url = cfg.get("API_BASE_URL")
 use_litellm = cfg.get("USE_LITELLM") == "true"
 additional_kwargs = {
     "timeout": int(cfg.get("REQUEST_TIMEOUT")),
-    "api_key": cfg.get("OPENAI_API_KEY"),
     "base_url": None if base_url == "default" else base_url,
 }
 
@@ -25,7 +24,7 @@ if use_litellm:
 else:
     from openai import OpenAI
 
-    client = OpenAI(**additional_kwargs)  # type: ignore
+    client = OpenAI(api_key=cfg.get("OPENAI_API_KEY"), **additional_kwargs)  # type: ignore
     completion = client.chat.completions.create
     additional_kwargs = {}
 


### PR DESCRIPTION
When the api_key is passed in additional kwargs to the litellm completion, it caused an issue with Azure OpenAI. 
To fix it, it is passed as an arg to the OpenAI instantiation, and removed from additional kwargs in the handler.

I don't know if this might cause issues for other LiteLLM backends though.
But if it does, it probably indicates that a refactor is needed in order handle multiple backends
