### PR TITLE
Only split config lines on the first =

### DIFF
--- a/sgpt/config.py
+++ b/sgpt/config.py
@@ -75,7 +75,7 @@ class Config(dict):  # type: ignore
         with open(self.config_path, "r", encoding="utf-8") as file:
             for line in file:
                 if line.strip() and not line.startswith("#"):
-                    key, value = line.strip().split("=")
+                    key, value = line.strip().split("=", 1)
                     self[key] = value
 
     def get(self, key: str) -> str:  # type: ignore


### PR DESCRIPTION
If a config value (such as the API key) has an = in it then it will currently blow up when parsing the config file. This will ensure that config values are only split into 2 items, keeping the values intact.

My enterprise key has an `=` in it and this is what I see 
![image](https://github.com/TheR1D/shell_gpt/assets/666270/62a8146b-1b90-4051-a2e5-95a9c95dee17)