### PR TITLE
Fix --show-chat and --repl to respect --no-md

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ sgpt --role json_generator "random: user, password, email, address"
 }
 ```
 
-If the description of the role contains the words "APPLY MARKDOWN" (case sensitive), then chats will be displayed using markdown formatting.
+If the description of the role contains the words "APPLY MARKDOWN" (case sensitive), then chats will be displayed using markdown formatting unless it is explicitly turned off with `--no-md`.
 
 ### Request cache
 Control cache using `--cache` (default) and `--no-cache` options. This caching applies for all `sgpt` requests to OpenAI API:

--- a/sgpt/app.py
+++ b/sgpt/app.py
@@ -107,7 +107,6 @@ def main(
     show_chat: str = typer.Option(
         None,
         help="Show all messages from provided chat id.",
-        callback=ChatHandler.show_messages_callback,
         rich_help_panel="Chat Options",
     ),
     list_chats: bool = typer.Option(
@@ -182,6 +181,9 @@ def main(
         except OSError:
             # Non-interactive shell.
             pass
+
+    if show_chat:
+        ChatHandler.show_messages(show_chat, md)
 
     if sum((shell, describe_shell, code)) > 1:
         raise BadArgumentUsage(

--- a/sgpt/handlers/chat_handler.py
+++ b/sgpt/handlers/chat_handler.py
@@ -127,9 +127,9 @@ class ChatHandler(Handler):
             typer.echo(chat_id)
 
     @classmethod
-    def show_messages(cls, chat_id: str) -> None:
+    def show_messages(cls, chat_id: str, markdown: bool) -> None:
         color = cfg.get("DEFAULT_COLOR")
-        if "APPLY MARKDOWN" in cls.initial_message(chat_id):
+        if "APPLY MARKDOWN" in cls.initial_message(chat_id) and markdown:
             theme = cfg.get("CODE_THEME")
             for message in cls.chat_session.get_messages(chat_id):
                 if message.startswith("assistant:"):
@@ -142,11 +142,6 @@ class ChatHandler(Handler):
         for index, message in enumerate(cls.chat_session.get_messages(chat_id)):
             running_color = color if index % 2 == 0 else "green"
             typer.secho(message, fg=running_color)
-
-    @classmethod
-    @option_callback
-    def show_messages_callback(cls, chat_id: str) -> None:
-        cls.show_messages(chat_id)
 
     def validate(self) -> None:
         if self.initiated:

--- a/sgpt/handlers/repl_handler.py
+++ b/sgpt/handlers/repl_handler.py
@@ -24,7 +24,7 @@ class ReplHandler(ChatHandler):
     def handle(self, init_prompt: str, **kwargs: Any) -> None:  # type: ignore
         if self.initiated:
             rich_print(Rule(title="Chat History", style="bold magenta"))
-            self.show_messages(self.chat_id)
+            self.show_messages(self.chat_id, self.markdown)
             rich_print(Rule(style="bold magenta"))
 
         info_message = (

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -70,7 +70,7 @@ def test_show_chat_no_use_markdown(completion, console_print):
     assert result.exit_code == 0
     assert chat_path.exists()
 
-    result = runner.invoke(app, ["--show-chat", chat_name])
+    result = runner.invoke(app, ["--show-chat", chat_name, "--no-md"])
     assert result.exit_code == 0
     console_print.assert_not_called()
 


### PR DESCRIPTION
I noticed that the options `--show-chat` and `--repl` does no respect the `--no-md` option and just checks for the "APPLY MARKDOWN" text in the role description. I fixed that. All tests and linting passed.