### PR TITLE
Fix shell identification

### DIFF
--- a/sgpt/utils.py
+++ b/sgpt/utils.py
@@ -73,11 +73,11 @@ def install_shell_integration(*_args: Any) -> None:
     # TODO: Add support for Windows.
     # TODO: Implement updates.
     shell = os.getenv("SHELL", "")
-    if shell == "/bin/zsh":
+    if "zsh" in shell:
         typer.echo("Installing ZSH integration...")
         with open(os.path.expanduser("~/.zshrc"), "a", encoding="utf-8") as file:
             file.write(zsh_integration)
-    elif shell == "/bin/bash":
+    elif "bash" in shell:
         typer.echo("Installing Bash integration...")
         with open(os.path.expanduser("~/.bashrc"), "a", encoding="utf-8") as file:
             file.write(bash_integration)


### PR DESCRIPTION
fixed bug where ```sgpt --install-integration``` fails for people who have bash or zsh in ```/usr/bin/```  by using ```"zsh" in shell``` 

This fixes #492 and #528 