### PR TITLE
Fix #329: Ability to follow up on one-off prompts with chat and repl

### DIFF
--- a/sgpt/app.py
+++ b/sgpt/app.py
@@ -2,13 +2,13 @@ import os
 
 # To allow users to use arrow keys in the REPL.
 import readline  # noqa: F401
+import shutil
 import sys
+from pathlib import Path
 
 import typer
-import shutil
 from click import BadArgumentUsage
 from click.types import Choice
-from pathlib import Path
 
 from sgpt.config import cfg
 from sgpt.function import get_openai_schemas
@@ -276,7 +276,7 @@ def main(
         break
 
 
-def register_last_chat(new_chat_id: str):
+def register_last_chat(new_chat_id: str) -> None:
     """
     Registers the last default chat as an actual chat in the ChatSessions.
 

--- a/sgpt/app.py
+++ b/sgpt/app.py
@@ -5,8 +5,10 @@ import readline  # noqa: F401
 import sys
 
 import typer
+import shutil
 from click import BadArgumentUsage
 from click.types import Choice
+from pathlib import Path
 
 from sgpt.config import cfg
 from sgpt.function import get_openai_schemas
@@ -104,6 +106,13 @@ def main(
         help="Start a REPL (Read–eval–print loop) session.",
         rich_help_panel="Chat Options",
     ),
+    follow_up: bool = typer.Option(
+        False,
+        "--follow-up",
+        "-fu",
+        help="Follow up on last prompt, " "used with --repl and --chat",
+        rich_help_panel="Chat Options",
+    ),
     show_chat: str = typer.Option(
         None,
         help="Show all messages from provided chat id.",
@@ -191,6 +200,11 @@ def main(
     if chat and repl:
         raise BadArgumentUsage("--chat and --repl options cannot be used together.")
 
+    if follow_up and not (chat or repl):
+        raise BadArgumentUsage(
+            "--follow-up option can only be used with --chat or --repl."
+        )
+
     if editor and stdin_passed:
         raise BadArgumentUsage("--editor option cannot be used with stdin input.")
 
@@ -204,6 +218,9 @@ def main(
     )
 
     function_schemas = (get_openai_schemas() or None) if functions else None
+
+    if follow_up:
+        register_last_chat(chat or repl)
 
     if repl:
         # Will be in infinite loop here until user exits with Ctrl+C.
@@ -257,6 +274,22 @@ def main(
             )
             continue
         break
+
+
+def register_last_chat(new_chat_id: str):
+    """
+    Registers the last default chat as an actual chat in the ChatSessions.
+
+    This enables following up on one-off prompts.
+    """
+    last_chat = Path(cfg.get("CACHE_PATH")) / "last_chat"
+    if not last_chat.exists():
+        return
+    new_chat = Path(cfg.get("CHAT_CACHE_PATH")) / new_chat_id
+    if new_chat.exists():
+        # Don't overwrite existing chats
+        return
+    shutil.copy(last_chat, new_chat)
 
 
 def entry_point() -> None:

--- a/sgpt/cache.py
+++ b/sgpt/cache.py
@@ -1,5 +1,5 @@
-from hashlib import md5
 import json
+from hashlib import md5
 from pathlib import Path
 from typing import Any, Callable, Dict, Generator, List, no_type_check
 
@@ -44,7 +44,7 @@ class Cache:
 
         return wrapper
 
-    def _cache_last_chat(self, kwargs: Dict[str, Any], response: str):
+    def _cache_last_chat(self, kwargs: Dict[str, Any], response: str) -> None:
         messages = kwargs.get("messages")
         if not messages:
             return


### PR DESCRIPTION
Adds new flag `--follow-up` (`-fu`) which can be used with `--repl` and `--chat` to pull in the last one-off prompt.

Implemented by keeping a `last_chat` file in the cache directory that's overwritten for every default prompt call (`sgpt "[some prompt]"`), and then copying this file over to the chat cache directory when `-fu` is specified.

![image](https://github.com/TheR1D/shell_gpt/assets/4934853/4a472ab8-7ccb-4826-9935-f5f665b425c7)

![image](https://github.com/TheR1D/shell_gpt/assets/4934853/6bab40e8-3743-4122-81ae-67dde9f32d2e)

