### PR TITLE
FORCE_USER_ROLE option to force api calls to use role:user instead of role:system

### DIFF
--- a/sgpt/app.py
+++ b/sgpt/app.py
@@ -155,6 +155,11 @@ def main(
         callback=inst_funcs,
         hidden=True,  # Hiding since should be used only once.
     ),
+    force_user_role: bool = typer.Option(
+        cfg.get("FORCE_USER_ROLE") == "true",
+        help="Force role: user in API calls",
+        rich_help_panel="Chat Options",
+    ),
 ) -> None:
     stdin_passed = not sys.stdin.isatty()
 

--- a/sgpt/config.py
+++ b/sgpt/config.py
@@ -34,6 +34,7 @@ DEFAULT_CONFIG = {
     "API_BASE_URL": os.getenv("API_BASE_URL", "default"),
     "PRETTIFY_MARKDOWN": os.getenv("PRETTIFY_MARKDOWN", "true"),
     "USE_LITELLM": os.getenv("USE_LITELLM", "false"),
+    "FORCE_USER_ROLE":  os.getenv("FORCE_USER_ROLE", "false"),
     # New features might add their own config variables here.
 }
 

--- a/sgpt/handlers/chat_handler.py
+++ b/sgpt/handlers/chat_handler.py
@@ -14,7 +14,7 @@ from .handler import Handler
 
 CHAT_CACHE_LENGTH = int(cfg.get("CHAT_CACHE_LENGTH"))
 CHAT_CACHE_PATH = Path(cfg.get("CHAT_CACHE_PATH"))
-
+FORCE_USER_ROLE = cfg.get("FORCE_USER_ROLE") == "true"
 
 class ChatSession:
     """
@@ -168,7 +168,8 @@ class ChatHandler(Handler):
     def make_messages(self, prompt: str) -> List[Dict[str, str]]:
         messages = []
         if not self.initiated:
-            messages.append({"role": "system", "content": self.role.role})
+            role = "system" if FORCE_USER_ROLE == False else "user"
+            messages.append({"role": role, "content": self.role.role})
         messages.append({"role": "user", "content": prompt})
         return messages
 

--- a/sgpt/handlers/default_handler.py
+++ b/sgpt/handlers/default_handler.py
@@ -7,7 +7,7 @@ from .handler import Handler
 
 CHAT_CACHE_LENGTH = int(cfg.get("CHAT_CACHE_LENGTH"))
 CHAT_CACHE_PATH = Path(cfg.get("CHAT_CACHE_PATH"))
-
+FORCE_USER_ROLE = cfg.get("FORCE_USER_ROLE") == "true"
 
 class DefaultHandler(Handler):
     def __init__(self, role: SystemRole, markdown: bool) -> None:
@@ -15,8 +15,9 @@ class DefaultHandler(Handler):
         self.role = role
 
     def make_messages(self, prompt: str) -> List[Dict[str, str]]:
+        role = "system" if FORCE_USER_ROLE == False else "user"
         messages = [
-            {"role": "system", "content": self.role.role},
+            {"role": role, "content": self.role.role},
             {"role": "user", "content": prompt},
         ]
         return messages


### PR DESCRIPTION
When using OpenAI compatible API like [textgen webui](https://github.com/oobabooga/text-generation-webui) some models do not support role:system in API calls, thus ignoring completely instructions how to behave and will add markdown in shell mode. 
This PR adds a config option FORCE_USER_ROLE to use in this scenario