### PR TITLE
Add support for reading `OPENAI_API_KEY` from a file path specified in the config

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,20 @@
+from sgpt.config import DEFAULT_CONFIG, Config
+
+
+def test_openai_api_key_string(tmp_path):
+    temp_config_path = tmp_path / "temp_file"
+    fake_api_key = "fake-api-key"
+    cfg = Config(temp_config_path, **{**DEFAULT_CONFIG, "OPENAI_API_KEY": fake_api_key})
+    assert cfg["OPENAI_API_KEY"] == fake_api_key
+
+
+def test_openai_api_key_path(tmp_path):
+    api_key_path = tmp_path / "api_key_file"
+    temp_config_path = tmp_path / "temp_file"
+    fake_api_key = "fake-api-key"
+
+    api_key_path.write_text(fake_api_key)
+    temp_config_path.write_text(f"OPENAI_API_KEY={api_key_path}")
+
+    cfg = Config(temp_config_path, **DEFAULT_CONFIG, OPENAI_API_KEY=api_key_path)
+    assert cfg["OPENAI_API_KEY"] == fake_api_key

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,4 @@
-from sgpt.config import DEFAULT_CONFIG, Config
+from sgpt.config import DEFAULT_CONFIG, POTENTIAL_PATH_KEYS, Config
 
 
 def test_openai_api_key_string(tmp_path):
@@ -18,3 +18,7 @@ def test_openai_api_key_path(tmp_path):
 
     cfg = Config(temp_config_path, **DEFAULT_CONFIG, OPENAI_API_KEY=api_key_path)
     assert cfg["OPENAI_API_KEY"] == fake_api_key
+
+
+def test_POTENTIAL_PATH_KEYS_includes_OPENAI_API_KEY():
+    assert "OPENAI_API_KEY" in POTENTIAL_PATH_KEYS


### PR DESCRIPTION
My sgpt config, including the .sgptrc file, is backed up via source control. This means I constantly need to manually make sure the `OPENAI_API_KEY` line is kept out of commits.

This is cumbersome and only takes one lapse in concentration to accidentally push my key.

This PR provides a simple fix by letting OPENAI_API_KEY point to a file path. This separate file would hold the key in plaintext, making it easier to keep out of version control.

![image](https://github.com/TheR1D/shell_gpt/assets/18548473/e4b3f856-fed5-488d-b983-64f3bebe8cb6)

Corresponding issue: #588 

Changes:
- Added `POTENTIAL_PATH_KEYS = ("OPENAI_API_KEY",)` at the module level in sgpt/config.py. When reading the config, this determines if the value should be checked for referencing an existing file. If so, it reads the file's contents.
- The logic of reading a config line, including the file path support, was extracted to a method — `def _read_from_line(self, line: str) -> None`.
  - It adds a minor OOS change, skipping lines starting with "#" AFTER stripping them.
- Added a new tests/test_config.py with three tests to cover both regression and the new behavior.

Please let me know if you want me to remove, modify, add an integration test or anything else.
Thanks!