### PR TITLE
Clean up temporary apt files in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3-slim
 WORKDIR /app
 COPY . /app
 
-RUN apt-get update && apt-get install -y gcc
+RUN apt-get update && apt-get install -y gcc && rm -rf /var/lib/apt/lists/*
 RUN pip install --no-cache /app && mkdir -p /tmp/shell_gpt
 
 VOLUME /tmp/shell_gpt


### PR DESCRIPTION
Clean up the apt lists file after package installation, just like using `--no-cache` with `pip install`, make the image a bit smaller.