### PR TITLE
Support all LiteLLM  supported models

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
 
 [project.optional-dependencies]
 litellm = [
-    "litellm == 1.24.5"
+    "litellm == 1.42.5"
 ]
 test = [
     "pytest >= 7.2.2, < 8.0.0",

--- a/sgpt/handlers/handler.py
+++ b/sgpt/handlers/handler.py
@@ -22,6 +22,7 @@ if use_litellm:
 
     completion = litellm.completion
     litellm.suppress_debug_info = True
+    additional_kwargs.pop("api_key")
 else:
     from openai import OpenAI
 


### PR DESCRIPTION
 Allow `litellm` to handle API key retrieval independently. Requiring `shell-gpt` to explicitly pass API keys would necessitate adding logic for all models supported by         
 `litellm`. This approach would be:                                                                                                                                              
                                                                                                                                                                                 
 1. Redundant, as `litellm` already manages this functionality                                                                                                                   
 2. Potentially exhaustive, given the extensive list of models `litellm` supports                                                                                                
                                                                                                                                                                                 
 By letting `litellm` manage API keys, we avoid unnecessary code duplication and maintain a more streamlined integration.