### PR TITLE
Fix: Setting permission of cache dir to allow multiple users to use cache.

### DIFF
--- a/sgpt/cache.py
+++ b/sgpt/cache.py
@@ -1,4 +1,4 @@
-import json
+import json, stat
 from hashlib import md5
 from pathlib import Path
 from typing import Any, Callable, Generator, no_type_check
@@ -18,6 +18,7 @@ class Cache:
         self.length = length
         self.cache_path = cache_path
         self.cache_path.mkdir(parents=True, exist_ok=True)
+        self.cache_path.chmod(0o777 | stat.S_ISVTX) # Enable multiple users to use the same cache
 
     def __call__(self, func: Callable[..., Any]) -> Callable[..., Any]:
         """

--- a/sgpt/handlers/chat_handler.py
+++ b/sgpt/handlers/chat_handler.py
@@ -1,4 +1,4 @@
-import json
+import json, stat
 from pathlib import Path
 from typing import Any, Callable, Dict, Generator, List, Optional
 
@@ -33,6 +33,7 @@ class ChatSession:
         self.length = length
         self.storage_path = storage_path
         self.storage_path.mkdir(parents=True, exist_ok=True)
+        self.storage_path.chmod(0o777 | stat.S_ISVTX) # Enable multiple users to use the same cache
 
     def __call__(self, func: Callable[..., Any]) -> Callable[..., Any]:
         """


### PR DESCRIPTION
Using shell-gpt on linux-like systems results in a permission denied error message for non-owners of cache directory on the same system.