### PR TITLE
Adopt to tool_calls format of oai doc fixing function call bugs and Support for parallel function call

### DIFF
--- a/sgpt/__main__.py
+++ b/sgpt/__main__.py
@@ -1,3 +1,3 @@
-from .app import entry_point
+from sgpt.app import entry_point
 
 entry_point()

--- a/sgpt/handlers/handler.py
+++ b/sgpt/handlers/handler.py
@@ -58,37 +58,46 @@ class Handler:
     def handle_function_call(
         self,
         messages: List[dict[str, Any]],
-        id: str,
-        name: str,
-        arguments: str,
+        name_map,
+        arguments_map,
     ) -> Generator[str, None, None]:
+        all_tool_calls = [
+            {
+                "id": id,
+                "type": "function",
+                "function": {"name": name, "arguments": arguments},
+            }
+            for id, name, arguments in zip(
+                name_map.keys(), name_map.values(), arguments_map.values()
+            )
+        ]
         messages.append(
             {
                 "role": "assistant",
                 "content": "",
-                "tool_calls": [
-                    {
-                        "id": id,
-                        "type": "function",
-                        "function": {"name": name, "arguments": arguments},
-                    }
-                ],
+                "tool_calls": all_tool_calls,
             }
         )
 
         if messages and messages[-1]["role"] == "assistant":
             yield "\n"
 
-        dict_args = json.loads(arguments)
-        joined_args = ", ".join(f'{k}="{v}"' for k, v in dict_args.items())
-        yield f"> @FunctionCall `{name}({joined_args})` \n\n"
+        all_function_res_msgs = []
+        for id, name, arguments in zip(
+            name_map.keys(), name_map.values(), arguments_map.values()
+        ):
+            dict_args = json.loads(arguments)
+            joined_args = ", ".join(f'{k}="{v}"' for k, v in dict_args.items())
+            yield f"> @FunctionCall `{name}({joined_args})` \n\n"
 
-        result = get_function(name)(**dict_args)
-        if cfg.get("SHOW_FUNCTIONS_OUTPUT") == "true":
-            yield f"```text\n{result}\n```\n"
-        messages.append(
-            {"role": "tool", "content": result, "tool_call_id": id, "name": name}
-        )
+            result = get_function(name)(**dict_args)
+            if cfg.get("SHOW_FUNCTIONS_OUTPUT") == "true":
+                yield f"```text\n{result}\n```\n"
+
+            all_function_res_msgs.append(
+                {"role": "tool", "content": result, "tool_call_id": id}
+            )
+        messages += all_function_res_msgs
 
     @cache
     def get_completion(
@@ -99,7 +108,6 @@ class Handler:
         messages: List[Dict[str, Any]],
         functions: Optional[List[Dict[str, str]]],
     ) -> Generator[str, None, None]:
-        name = arguments = ""
         is_shell_role = self.role.name == DefaultRoles.SHELL.value
         is_code_role = self.role.name == DefaultRoles.CODE.value
         is_dsc_shell_role = self.role.name == DefaultRoles.DESCRIBE_SHELL.value
@@ -140,12 +148,11 @@ class Handler:
                         else:
                             arguments_map[id] += tool_call.function.arguments
                 if chunk.choices[0].finish_reason == "tool_calls":
-                    for id, name, arguments in zip(
-                        name_map.keys(), name_map.values(), arguments_map.values()
-                    ):
-                        yield from self.handle_function_call(
-                            messages, id, name, arguments
-                        )
+                    yield from self.handle_function_call(
+                        messages,
+                        name_map,
+                        arguments_map,
+                    )
                     yield from self.get_completion(
                         model=model,
                         temperature=temperature,

--- a/sgpt/handlers/handler.py
+++ b/sgpt/handlers/handler.py
@@ -58,6 +58,7 @@ class Handler:
     def handle_function_call(
         self,
         messages: List[dict[str, Any]],
+        id: str,
         name: str,
         arguments: str,
     ) -> Generator[str, None, None]:
@@ -65,7 +66,13 @@ class Handler:
             {
                 "role": "assistant",
                 "content": "",
-                "function_call": {"name": name, "arguments": arguments},
+                "tool_calls": [
+                    {
+                        "id": id,
+                        "type": "function",
+                        "function": {"name": name, "arguments": arguments},
+                    }
+                ],
             }
         )
 
@@ -79,7 +86,9 @@ class Handler:
         result = get_function(name)(**dict_args)
         if cfg.get("SHOW_FUNCTIONS_OUTPUT") == "true":
             yield f"```text\n{result}\n```\n"
-        messages.append({"role": "function", "content": result, "name": name})
+        messages.append(
+            {"role": "tool", "content": result, "tool_call_id": id, "name": name}
+        )
 
     @cache
     def get_completion(
@@ -121,12 +130,14 @@ class Handler:
                 )
                 if tool_calls:
                     for tool_call in tool_calls:
+                        if tool_call.id:
+                            id = tool_call.id
                         if tool_call.function.name:
                             name = tool_call.function.name
                         if tool_call.function.arguments:
                             arguments += tool_call.function.arguments
                 if chunk.choices[0].finish_reason == "tool_calls":
-                    yield from self.handle_function_call(messages, name, arguments)
+                    yield from self.handle_function_call(messages, id, name, arguments)
                     yield from self.get_completion(
                         model=model,
                         temperature=temperature,


### PR DESCRIPTION
I'm using deepseek api(which is oai compatible), which i found the code fail to return the function call result:
e.g.
![image](https://github.com/user-attachments/assets/a774a80a-9d25-49f9-971a-89506a6a3c2b)

> UnprocessableEntityError: Failed to deserialize the JSON body into the target type: messages[3].role: unknown variant `function`, expected one of `system`, `user`, `assistant`, `tool` at line 1 column 666

which i think is relate to this part of code: https://github.com/TheR1D/shell_gpt/blob/ab6b475c9da1d4b28c16e5fd963fc434fdfd3356/sgpt/handlers/handler.py#L64C1-L82C79

I make some changes to adopt to oai function doc:

```
`# Create a message containing the result of the function call
function_call_result_message = {
    "role": "tool",
    "content": json.dumps({
        "order_id": order_id,
        "delivery_date": delivery_date.strftime('%Y-%m-%d %H:%M:%S')
    }),
    "tool_call_id": response['choices'][0]['message']['tool_calls'][0]['id']
}`
```
which indecate that the role should be tool and tool_call_id is needed

after the modification the code work fine and i have run the lint and test