### PR TITLE
feat: Extract shell command from backticks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ python -m venv env && source ./env/bin/activate
 Install the necessary dependencies, including development and test dependencies:
 
 ```shell
-pip install -e ."[dev,test]"
+pip install -e ."[dev,test,litellm]"
 ```
 
 ### Start Coding

--- a/sgpt/handlers/handler.py
+++ b/sgpt/handlers/handler.py
@@ -1,4 +1,5 @@
 import json
+import re
 from pathlib import Path
 from typing import Any, Callable, Dict, Generator, List, Optional
 
@@ -37,6 +38,7 @@ class Handler:
 
     def __init__(self, role: SystemRole, markdown: bool) -> None:
         self.role = role
+        self.is_shell = role.name == DefaultRoles.SHELL.value
 
         api_base_url = cfg.get("API_BASE_URL")
         self.base_url = None if api_base_url == "default" else api_base_url
@@ -44,6 +46,13 @@ class Handler:
 
         self.markdown = "APPLY MARKDOWN" in self.role.role and markdown
         self.code_theme, self.color = cfg.get("CODE_THEME"), cfg.get("DEFAULT_COLOR")
+
+        self.backticks_start = re.compile(r"(^|[\r\n]+)```\w*[\r\n]+")
+        end_regex_parts = [r"[\r\n]+", "`", "`", "`", r"([\r\n]+|$)"]
+        self.backticks_end_prefixes = [
+            re.compile("".join(end_regex_parts[: i + 1]))
+            for i in range(len(end_regex_parts))
+        ]
 
     @property
     def printer(self) -> Printer:
@@ -81,6 +90,48 @@ class Handler:
         if cfg.get("SHOW_FUNCTIONS_OUTPUT") == "true":
             yield f"```text\n{result}\n```\n"
         messages.append({"role": "function", "content": result, "name": name})
+
+    def _matches_end_at(self, text: str) -> tuple[bool, int]:
+        end_of_match = 0
+        for _i, regex in enumerate(self.backticks_end_prefixes):
+            m = regex.search(text)
+            if m:
+                end_of_match = m.end()
+            else:
+                return False, end_of_match
+        return True, m.start()
+
+    def _filter_chunks(
+        self, chunks: Generator[str, None, None]
+    ) -> Generator[str, None, None]:
+        buffer = ""
+        inside_backticks = False
+        end_of_beginning = 0
+
+        for chunk in chunks:
+            buffer += chunk
+            if not inside_backticks:
+                m = self.backticks_start.search(buffer)
+                if not m:
+                    continue
+                new_end_of_beginning = m.end()
+                if new_end_of_beginning > end_of_beginning:
+                    end_of_beginning = new_end_of_beginning
+                    continue
+                inside_backticks = True
+                buffer = buffer[end_of_beginning:]
+            if inside_backticks:
+                matches_end, index = self._matches_end_at(buffer)
+                if matches_end:
+                    yield buffer[:index]
+                    return
+                if index == len(buffer):
+                    continue
+                else:
+                    yield buffer
+                    buffer = ""
+        if buffer:
+            yield buffer
 
     @cache
     def get_completion(
@@ -163,4 +214,6 @@ class Handler:
             caching=caching,
             **kwargs,
         )
+        if self.role.name == DefaultRoles.SHELL.value:
+            generator = self._filter_chunks(generator)
         return self.printer(generator, not disable_stream)


### PR DESCRIPTION
## What is done?
A produced command is extracted from markdown backticks in `--shell` mode

## Why?
Because LLMs are usually taught to produce markdown output. So, even if you ask gently in a prompt, you get markdown backticks most of the time. You will get it especially often on small models, e.g., when running Ollama.

## What I tested
- If LLM generates no backticks, it's output is returned as is
- LLM generates multiline command
- LLM generates a command which itself contains backticks for some reason (e.g., you ask to `grep -rnI "```"`)
- LLM generates a surrounding comment text with backticks
- Windows/Linux/Mac-style newlines

## P.S.
Hope other Ollama guys like me will now be happy. Please like this PR if you are.

With this PR I can finally do `DEFAULT_MODEL=ollama/qwen2.5-coder:3b-instruct-q6_K`.
