### PR TITLE
update readme pipx install usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ https://github.com/TheR1D/shell_gpt/assets/16740832/9197283c-db6a-4b46-bfea-3eb7
 
 ## Installation
 ```shell
-pip install shell-gpt
+pipx install 'shell-gpt[litellm]'
 ```
 By default, ShellGPT uses OpenAI's API and GPT-4 model. You'll need an API key, you can generate one [here](https://beta.openai.com/account/api-keys). You will be prompted for your key which will then be stored in `~/.config/shell_gpt/.sgptrc`. OpenAI API is not free of charge, please refer to the [OpenAI pricing](https://openai.com/pricing) for more information.
 


### PR DESCRIPTION
I've updated readme to use pipx instead of pip
since python gives you an error with pip install now

Solves
#635
#594