### PR TITLE
Add basic instructions for using xAI Grok.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ By default, ShellGPT uses OpenAI's API and GPT-4 model. You'll need an API key, 
 > [!TIP]
 > Alternatively, you can use locally hosted open source models which are available for free. To use local models, you will need to run your own LLM backend server such as [Ollama](https://github.com/ollama/ollama). To set up ShellGPT with Ollama, please follow this comprehensive [guide](https://github.com/TheR1D/shell_gpt/wiki/Ollama).
 >
-> xAI Grok also maintains some level of backwards compatability with the OpenAI API.
+> xAI Grok also maintains backwards compatability with the OpenAI API.
 > You may use an xAI token with Grok2 like so
 ```
 export OPENAI_API_KEY='xai-xxxx'

--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@ By default, ShellGPT uses OpenAI's API and GPT-4 model. You'll need an API key, 
 > [!TIP]
 > Alternatively, you can use locally hosted open source models which are available for free. To use local models, you will need to run your own LLM backend server such as [Ollama](https://github.com/ollama/ollama). To set up ShellGPT with Ollama, please follow this comprehensive [guide](https://github.com/TheR1D/shell_gpt/wiki/Ollama).
 >
+> xAI Grok also maintains some level of backwards compatability with the OpenAI API.
+> You may use an xAI token with Grok2 like so
+```
+export OPENAI_API_KEY='xai-xxxx'
+export DEFAULT_MODEL="grok-beta" #Or whatever model is listed at the time, and preferred.
+export API_BASE_URL=https://api.x.ai/v1
+```
+> Basic testing done, but *your mileage may vary*.
+
 > **❗️Note that ShellGPT is not optimized for local models and may not work as expected.**
 
 ## Usage


### PR DESCRIPTION
I wanted to see if xAI's grok is supported, but could not find any existing docs/pull-requests/issues/discussions or instructions.

https://x.ai/blog/api

```
API
To learn more about our API, check out our documentation at [docs.x.ai](https://docs.x.ai/). Our REST API is fully compatible with the ones offered by OpenAI and Anthropic. This simplifies migration. For example, if you’re currently using the OpenAI Python SDK, you can start using Grok by simply changing the base_url to https://api.x.ai/v1 and using your xAI API key that you created on [console.x.ai](https://console.x.ai/).
The xAI API is 
```

As such I've figured out how to make it work and this PR adds instructions accordingly:

```
export OPENAI_API_KEY='xai-xxxx'
export DEFAULT_MODEL="grok-beta" #Or whatever model is listed at the time, and preferred.
export API_BASE_URL=https://api.x.ai/v1
```