### PR TITLE
Add OpenAI API Key Update Command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+myvenv
+__pycache__

--- a/README.md
+++ b/README.md
@@ -429,6 +429,7 @@ Possible options for `CODE_THEME`: https://pygments.org/styles/
 │ --editor                                      Open $EDITOR to provide a prompt. [default: no-editor]     │
 │ --cache                                       Cache completion results. [default: cache]                 │
 │ --version                                     Show version.                                              │
+| --updateAPI                                   Update OpenAI API key                                      |
 │ --help                                        Show this message and exit.                                │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Assistance Options ─────────────────────────────────────────────────────────────────────────────────────╮

--- a/sgpt/app.py
+++ b/sgpt/app.py
@@ -94,6 +94,11 @@ def main(
         help="Show version.",
         callback=get_sgpt_version,
     ),
+    updateAPI: bool = typer.Option(
+        False,
+        "--updateAPI",
+        help="Update OpenAI API key",  
+    ),
     chat: str = typer.Option(
         None,
         help="Follow conversation with id, " 'use "temp" for quick session.',
@@ -225,6 +230,11 @@ def main(
             caching=cache,
             functions=function_schemas,
         )
+
+    if updateAPI:
+        cfg.update_API_key
+        return
+    
     else:
         full_completion = DefaultHandler(role_class, md).handle(
             prompt=prompt,

--- a/sgpt/config.py
+++ b/sgpt/config.py
@@ -87,6 +87,13 @@ class Config(dict):  # type: ignore
         if not value:
             raise UsageError(f"Missing config key: {key}")
         return value
-
+    
+    @property
+    def update_API_key(self) -> None:
+        __newvalue = getpass(prompt="Please enter a valid OpenAI API key: ")
+        self["OPENAI_API_KEY"] = __newvalue
+        self._write()
+        
+        
 
 cfg = Config(SHELL_GPT_CONFIG_PATH, **DEFAULT_CONFIG)


### PR DESCRIPTION
## Problem #593 #549 
Users occasionally enter incorrect OpenAI API keys during setup, and changing the key requires manual editing of the config file. This creates friction and could lead to user errors when modifying configuration files directly.

## Solution
Added a new command line option `--updateAPI` that allows users to update their OpenAI API key through a simple interactive prompt:
```sh
sgpt --updateAPI
```
