### PR TITLE
fix for 'NoneType' object has no attribute 'tool_calls' issue

### DIFF
--- a/sgpt/handlers/handler.py
+++ b/sgpt/handlers/handler.py
@@ -116,6 +116,8 @@ class Handler:
             for chunk in response:
                 delta = chunk.choices[0].delta
 
+                if not delta: continue
+
                 # LiteLLM uses dict instead of Pydantic object like OpenAI does.
                 tool_calls = (
                     delta.get("tool_calls") if use_litellm else delta.tool_calls


### PR DESCRIPTION
See https://github.com/TheR1D/shell_gpt/issues/662

Proposed fix by checking if `delta` is not None and if so just continuing the for loop. Another option would be to add a try catch around the `delta.get("tool_calls") if use_litellm else delta.tool_calls`. Let me know!