### PR TITLE
Fix: Preserve the first item in the chat message cache containing the initial role

### DIFF
--- a/sgpt/handlers/chat_handler.py
+++ b/sgpt/handlers/chat_handler.py
@@ -71,7 +71,8 @@ class ChatSession:
 
     def _write(self, messages: List[Dict[str, str]], chat_id: str) -> None:
         file_path = self.storage_path / chat_id
-        json.dump(messages[-self.length :], file_path.open("w"))
+        message_role_item = messages.pop(0)
+        json.dump([message_role_item] + messages[-self.length :], file_path.open("w"))
 
     def invalidate(self, chat_id: str) -> None:
         file_path = self.storage_path / chat_id


### PR DESCRIPTION
I made a simple fix addressing the following issue. I'm not a Python developer, but it's just a straightforward modification.

related issue:
https://github.com/TheR1D/shell_gpt/issues/633