### PR TITLE
Add copy to clipboard options for shell commands

### DIFF
--- a/sgpt/app.py
+++ b/sgpt/app.py
@@ -7,6 +7,7 @@ import sys
 import typer
 from click import BadArgumentUsage
 from click.types import Choice
+from pyperclip import copy as pyperclip_copy
 
 from sgpt.config import cfg
 from sgpt.function import get_openai_schemas
@@ -238,9 +239,16 @@ def main(
         )
 
     while shell and interaction:
+        choices = ("e", "d", "a", "y")
+        prompt_text = "[E]xecute, [D]escribe, [A]bort"
+        
+        if cfg.get("COPY_SHELL_CMD_TO_CLIPBOARD") == "true":
+            choices = (*choices, "c")
+            prompt_text += ", [C]opy"
+            
         option = typer.prompt(
-            text="[E]xecute, [D]escribe, [A]bort",
-            type=Choice(("e", "d", "a", "y"), case_sensitive=False),
+            text=prompt_text,
+            type=Choice(choices, case_sensitive=False),
             default="e" if cfg.get("DEFAULT_EXECUTE_SHELL_CMD") == "true" else "a",
             show_choices=False,
             show_default=False,
@@ -258,6 +266,11 @@ def main(
                 functions=function_schemas,
             )
             continue
+        elif option == "c":
+            pyperclip_copy(full_completion)
+            typer.echo("Command copied to clipboard")
+            continue
+        
         break
 
 

--- a/sgpt/config.py
+++ b/sgpt/config.py
@@ -37,6 +37,7 @@ DEFAULT_CONFIG = {
     "SHELL_INTERACTION": os.getenv("SHELL_INTERACTION ", "true"),
     "OS_NAME": os.getenv("OS_NAME", "auto"),
     "SHELL_NAME": os.getenv("SHELL_NAME", "auto"),
+    "COPY_SHELL_CMD_TO_CLIPBOARD": os.getenv("COPY_SHELL_CMD_TO_CLIPBOARD", "true"),
     # New features might add their own config variables here.
 }
 

--- a/sgpt/utils.py
+++ b/sgpt/utils.py
@@ -6,9 +6,12 @@ from typing import Any, Callable
 
 import typer
 from click import BadParameter, UsageError
+from pyperclip import copy as pyperclip_copy
 
 from sgpt.__version__ import __version__
 from sgpt.integration import bash_integration, zsh_integration
+
+from sgpt.config import cfg
 
 
 def get_edited_prompt() -> str:
@@ -50,6 +53,8 @@ def run_command(command: str) -> None:
         shell = os.environ.get("SHELL", "/bin/sh")
         full_command = f"{shell} -c {shlex.quote(command)}"
 
+    if cfg.get("COPY_SHELL_CMD_TO_CLIPBOARD") == "true":
+        pyperclip_copy(full_command)
     os.system(full_command)
 
 


### PR DESCRIPTION
- Enhancement: Automatically add shell commands to system clipboard on execution when using `sgpt --shell "<shell-cmd-prompt>"`

- Feature: Add "[C]opy" option to shell command prompt

_Both are disabled if ENV var 'COPY_SHELL_CMD_TO_CLIPBOARD' is 'false'. Defaults to true._

