### PR TITLE
fix: handle empty chunks in response stream

### DIFF
--- a/sgpt/handlers/handler.py
+++ b/sgpt/handlers/handler.py
@@ -114,6 +114,9 @@ class Handler:
 
         try:
             for chunk in response:
+                if not chunk.choices:
+                    yield ""
+                    continue  # Skip the rest of this loop iteration if stream is empty
                 delta = chunk.choices[0].delta
 
                 # LiteLLM uses dict instead of Pydantic object like OpenAI does.


### PR DESCRIPTION
## Description
This PR fixes an issue with empty chunks in the response stream that could cause errors when processing streaming responses.

## Changes
- Added handling for empty `chunk.choices` in the response stream
- Skip empty chunks gracefully by yielding an empty string and continuing the loop

## Related Issues
- Fixed the streaming API that may return an empty data block causing an out-of-index error.

## Additional Notes
This change makes the streaming handler more robust by properly handling edge cases in the response stream without breaking the processing flow.