### PR TITLE
Add --fix option to correct the last command (#698)

### DIFF
--- a/sgpt/app.py
+++ b/sgpt/app.py
@@ -227,10 +227,9 @@ def main(
             functions=function_schemas,
         )
 
-    if prompt == "":
-        raise BadArgumentUsage(
-            "Prompt cant be empty. Use `sgpt <prompt>` to get started."
-        )
+    if not prompt:
+        print("Prompt cant be empty. Use `sgpt <prompt>` to get started.")
+        return
 
     if chat:
         full_completion = ChatHandler(chat, role_class, md).handle(
@@ -251,9 +250,8 @@ def main(
             functions=function_schemas,
         )
 
-    command = extract_command_from_completion(full_completion)
-
     while shell and interaction:
+        command = extract_command_from_completion(full_completion)
         option = typer.prompt(
             text="[E]xecute, [D]escribe, [A]bort",
             type=Choice(("e", "d", "a", "y"), case_sensitive=False),

--- a/sgpt/app.py
+++ b/sgpt/app.py
@@ -17,6 +17,7 @@ from sgpt.llm_functions.init_functions import install_functions as inst_funcs
 from sgpt.role import DefaultRoles, SystemRole
 from sgpt.utils import (
     get_edited_prompt,
+    get_fixed_prompt,
     get_sgpt_version,
     install_shell_integration,
     run_command,
@@ -83,6 +84,10 @@ def main(
     editor: bool = typer.Option(
         False,
         help="Open $EDITOR to provide a prompt.",
+    ),
+    fix: bool = typer.Option(
+        False,
+        help="Fix the wrong last command.",
     ),
     cache: bool = typer.Option(
         True,
@@ -198,6 +203,9 @@ def main(
 
     if editor:
         prompt = get_edited_prompt()
+
+    if fix:
+        prompt = get_fixed_prompt()
 
     role_class = (
         DefaultRoles.check_get(shell, describe_shell, code)

--- a/sgpt/app.py
+++ b/sgpt/app.py
@@ -228,7 +228,8 @@ def main(
         )
 
     if not prompt:
-        print("Prompt cant be empty. Use `sgpt <prompt>` to get started.")
+        if not show_chat:
+            print("Prompt cant be empty. Use `sgpt <prompt>` to get started.")
         return
 
     if chat:

--- a/sgpt/command.py
+++ b/sgpt/command.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+from click import UsageError
+import json
+
+
+class Command:
+    def __init__(self, command_path: Path):
+        self.command_path = command_path
+        self.command_path.mkdir(parents=True, exist_ok=True)
+
+    def get_last_command(self) -> tuple[str, str]:
+        """
+        get the last command and output from the command path
+        """
+        last_command_file = self.command_path / "last_command.json"
+        if not last_command_file.exists():
+            raise UsageError("No last command and output found.")
+        with open(last_command_file, "r", encoding="utf-8") as file:
+            data = json.load(file)
+            command = data.get("command", "")
+            output = data.get("output", "")
+            return command, output
+
+    def set_last_command(self, command: str, output: str) -> None:
+        """
+        set the last command and output to the command path
+        """
+        last_command_file = self.command_path / "last_command.json"
+        with open(last_command_file, "w", encoding="utf-8") as file:
+            data = {"command": command, "output": output}
+            json.dump(data, file, ensure_ascii=False)

--- a/sgpt/config.py
+++ b/sgpt/config.py
@@ -13,6 +13,7 @@ ROLE_STORAGE_PATH = SHELL_GPT_CONFIG_FOLDER / "roles"
 FUNCTIONS_PATH = SHELL_GPT_CONFIG_FOLDER / "functions"
 CHAT_CACHE_PATH = Path(gettempdir()) / "chat_cache"
 CACHE_PATH = Path(gettempdir()) / "cache"
+COMMAND_PATH = Path(gettempdir()) / "commands"
 
 # TODO: Refactor ENV variables with SGPT_ prefix.
 DEFAULT_CONFIG = {
@@ -37,6 +38,7 @@ DEFAULT_CONFIG = {
     "SHELL_INTERACTION": os.getenv("SHELL_INTERACTION ", "true"),
     "OS_NAME": os.getenv("OS_NAME", "auto"),
     "SHELL_NAME": os.getenv("SHELL_NAME", "auto"),
+    "COMMAND_PATH": os.getenv("COMMAND_PATH", str(COMMAND_PATH)),
     # New features might add their own config variables here.
 }
 

--- a/sgpt/utils.py
+++ b/sgpt/utils.py
@@ -1,4 +1,5 @@
 import os
+import re
 from pathlib import Path
 import platform
 import shlex
@@ -46,6 +47,15 @@ def get_fixed_prompt() -> str:
     """
     command, output = command_helper.get_last_command()
     return f"The last command `{command}` failed with error:\n{output}\nPlease fix it."
+
+
+def extract_command_from_completion(completion: str) -> str:
+    """
+    using regex to extract the command from the completion
+    """
+    if match := re.search(r"```(.*sh)?(.*?)```", completion, re.DOTALL):
+        return match[2].strip()
+    return completion
 
 
 def run_command(command: str) -> None:


### PR DESCRIPTION
Hi! Backgroud and motivation from #698

When I got an error command, I would like to correct ai that `the command ... was wrong with the output ..., please fix it`.

example follows:
<img width="1175" alt="image" src="https://github.com/user-attachments/assets/f94477ed-8dfe-428a-9957-48be419f1843" />

This PR introduces a `--fix` flag. When used, sgpt retrieves the last executed command and its output, then prompts the AI to provide a corrected version based on the error.

Key changes:

- Added `--fix` option to `sgpt/app.py`.
- Created `sgpt/command.py` to manage storing and retrieving the last command and output in json format.
- Updated `sgpt/utils.py` to set and get the last command.
- Replaced `os.system` with `subprocess.Popen` in `run_command` to capture output.
- Added `get_fixed_prompt` to generate the prompt for the AI.
- Store command and output using the new Command class.
- Updated tests in `tests/test_shell.py` to reflect the use of `subprocess`.
- Added necessary configuration in `sgpt/config.py`.

make sure the lint and test result as usual:
<img width="1186" alt="image" src="https://github.com/user-attachments/assets/c3f7a0b3-5f39-4f9d-ae24-3f92b2cc9c0c" />

Closes #698

