### PR TITLE
Change default model from gpt-4o to gpt-4.1

### DIFF
--- a/sgpt/config.py
+++ b/sgpt/config.py
@@ -22,7 +22,7 @@ DEFAULT_CONFIG = {
     "CHAT_CACHE_LENGTH": int(os.getenv("CHAT_CACHE_LENGTH", "100")),
     "CACHE_LENGTH": int(os.getenv("CHAT_CACHE_LENGTH", "100")),
     "REQUEST_TIMEOUT": int(os.getenv("REQUEST_TIMEOUT", "60")),
-    "DEFAULT_MODEL": os.getenv("DEFAULT_MODEL", "gpt-4o"),
+    "DEFAULT_MODEL": os.getenv("DEFAULT_MODEL", "gpt-4.1"),
     "DEFAULT_COLOR": os.getenv("DEFAULT_COLOR", "magenta"),
     "ROLE_STORAGE_PATH": os.getenv("ROLE_STORAGE_PATH", str(ROLE_STORAGE_PATH)),
     "DEFAULT_EXECUTE_SHELL_CMD": os.getenv("DEFAULT_EXECUTE_SHELL_CMD", "false"),


### PR DESCRIPTION
## Overview

This pull request updates the default model used by ShellGPT from **`gpt-4o`** to **`gpt-4.1`**.

---

## Details

- Changed the value of `DEFAULT_MODEL` from `gpt-4o` to `gpt-4.1` in the runtime configuration.
- This change will make ShellGPT use `gpt-4.1` as the default model for new requests.

---

## Motivation

Recent updates from OpenAI have made the current `gpt-4o` model **fully backward-compatible with `gpt-4.1`**.  
As a result, `gpt-4.1` now offers both **higher accuracy** and **better cost performance** compared to `gpt-4o`.

Therefore, I would like to update the default model in this product to `gpt-4.1` to ensure that users benefit from improved accuracy and reduced cost by default.

---

## Impact

- All new requests without an explicitly specified model will now use `gpt-4.1`.
- No major breaking changes are expected, but please let me know if any additional changes are needed.

---

Thank you for reviewing this PR!