### PR TITLE
Fixed the bugs in the [E]xecute, [D]escribe functions caused by the r1 mode.

### DIFF
--- a/sgpt/app.py
+++ b/sgpt/app.py
@@ -19,6 +19,7 @@ from sgpt.utils import (
     get_edited_prompt,
     get_sgpt_version,
     install_shell_integration,
+    extract_command,
     run_command,
 )
 
@@ -238,6 +239,7 @@ def main(
         )
 
     while shell and interaction:
+        full_completion = extract_command(full_completion)
         option = typer.prompt(
             text="[E]xecute, [D]escribe, [A]bort",
             type=Choice(("e", "d", "a", "y"), case_sensitive=False),

--- a/sgpt/handlers/repl_handler.py
+++ b/sgpt/handlers/repl_handler.py
@@ -5,7 +5,7 @@ from rich import print as rich_print
 from rich.rule import Rule
 
 from ..role import DefaultRoles, SystemRole
-from ..utils import run_command
+from ..utils import run_command, extract_command
 from .chat_handler import ChatHandler
 from .default_handler import DefaultHandler
 
@@ -64,3 +64,4 @@ class ReplHandler(ChatHandler):
                 ).handle(prompt=full_completion, **kwargs)
             else:
                 full_completion = super().handle(prompt=prompt, **kwargs)
+                full_completion = extract_command(full_completion)

--- a/sgpt/utils.py
+++ b/sgpt/utils.py
@@ -1,4 +1,5 @@
 import os
+import re
 import platform
 import shlex
 from tempfile import NamedTemporaryFile
@@ -31,6 +32,20 @@ def get_edited_prompt() -> str:
     if not output:
         raise BadParameter("Couldn't get valid PROMPT from $EDITOR")
     return output
+
+
+def extract_command(full_completion: str) -> str:
+    if '</think>' in full_completion:
+        _, _, after_think = full_completion.partition('</think>')
+        match (
+            re.search(r"```(?:bash)?\s*([\s\S]*?)\s*```", after_think),
+            re.search(r'`([^`]+)`', after_think),
+        ):
+            case (code_block, _) if code_block:
+                return code_block.group(1).strip()
+            case (_, code_line) if code_line:
+                return code_line.group(1).strip()
+    return full_completion
 
 
 def run_command(command: str) -> None:


### PR DESCRIPTION
When using the r1 model, there are errors in the [E]xecute and [D]escribe modes (because the </think> part is not filtered out, and </think> is also parsed as a generate command.

![e_bug](https://github.com/user-attachments/assets/1337719b-60f3-4b93-acfb-9aa141f59db0)
![d_bug](https://github.com/user-attachments/assets/0dfd2736-6673-4f58-8588-a534dbb314ff)

Changes have been made to both the --shell and --repl xxx -s options, and the [E]xecute and [D]escribe modes are now functioning properly.

![e_d_run](https://github.com/user-attachments/assets/3739e2e1-888f-416c-ba5a-49016d180561)

@TheR1D @eric-glb @cosmojg @startakovsky @jeanlucthumm 
