### PR TITLE
feat: add `DEFAULT_TEMPERATURE` to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,8 @@ CACHE_PATH=/tmp/shell_gpt/cache
 REQUEST_TIMEOUT=60
 # Default OpenAI model to use.
 DEFAULT_MODEL=gpt-4o
+# Default temperature value to use.
+DEFAULT_TEMPERATURE=0.0
 # Default color for shell and code completions.
 DEFAULT_COLOR=magenta
 # When in --shell mode, default to "Y" for no input.

--- a/sgpt/config.py
+++ b/sgpt/config.py
@@ -23,6 +23,7 @@ DEFAULT_CONFIG = {
     "CACHE_LENGTH": int(os.getenv("CHAT_CACHE_LENGTH", "100")),
     "REQUEST_TIMEOUT": int(os.getenv("REQUEST_TIMEOUT", "60")),
     "DEFAULT_MODEL": os.getenv("DEFAULT_MODEL", "gpt-4o"),
+    "DEFAULT_TEMPERATURE": float(os.getenv("DEFAULT_TEMPERATURE", "0.0")),
     "DEFAULT_COLOR": os.getenv("DEFAULT_COLOR", "magenta"),
     "ROLE_STORAGE_PATH": os.getenv("ROLE_STORAGE_PATH", str(ROLE_STORAGE_PATH)),
     "DEFAULT_EXECUTE_SHELL_CMD": os.getenv("DEFAULT_EXECUTE_SHELL_CMD", "false"),


### PR DESCRIPTION
With the recent releases of the `gpt-5`, `gpt-5-mini` and `gpt-5-nano` models, along with the `o4-mini` models referenced in #692 , a custom temperature value isn't support and thus all require a temperate value of `1`. Currently the application throws an error if the default `0` value is used.

This PR introduces a `DEFAULT_TEMPERATURE` to the config so that if you already set a default model, you then don't need to use the `--temperature` flag every call.