### PR TITLE
Fix handle empty stream chunks and enforce UTF-8 cache writes

### DIFF
--- a/sgpt/cache.py
+++ b/sgpt/cache.py
@@ -38,7 +38,7 @@ class Cache:
                 result += i
                 yield i
             if "@FunctionCall" not in result:
-                file.write_text(result)
+                file.write_text(result, encoding="utf-8")
             self._delete_oldest_files(self.length)  # type: ignore
 
         return wrapper

--- a/sgpt/handlers/handler.py
+++ b/sgpt/handlers/handler.py
@@ -114,6 +114,8 @@ class Handler:
 
         try:
             for chunk in response:
+                if not chunk.choices:
+                    continue
                 delta = chunk.choices[0].delta
 
                 # LiteLLM uses dict instead of Pydantic object like OpenAI does.


### PR DESCRIPTION
- Add safety check to skip empty/non-standard stream chunks from third-party APIs.
- Write cache files using UTF-8 to avoid Windows GBK errors caused by emoji output.