### PR TITLE
Add check for empty choices in response chunks

### DIFF
--- a/sgpt/handlers/handler.py
+++ b/sgpt/handlers/handler.py
@@ -114,6 +114,8 @@ class Handler:
 
         try:
             for chunk in response:
+                if not chunk.choices:
+                    continue
                 delta = chunk.choices[0].delta
 
                 # LiteLLM uses dict instead of Pydantic object like OpenAI does.


### PR DESCRIPTION
This pull request introduces a small update to the `get_completion` function in `sgpt/handlers/handler.py` to improve robustness when handling streaming responses.

* Added a check to skip response chunks that do not contain any choices, preventing potential errors when accessing `chunk.choices[0]`.