### PR TITLE
Document PowerShell solution for ShellGPT integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,72 @@ https://github.com/TheR1D/shell_gpt/assets/16740832/bead0dab-0dd9-436d-88b7-6abf
 
 To install shell integration, run `sgpt --install-integration` and restart your terminal to apply changes. This will add few lines to your `.bashrc` or `.zshrc` file. After that, you can use `Ctrl+l` (by default) to invoke ShellGPT. When you press `Ctrl+l` it will replace you current input line (buffer) with suggested command. You can then edit it and just press `Enter` to execute.
 
+#### Solution for Powershell
+You can use this script (e.g. in your profile.ps1) to mimic the same feature on Powershell
+```
+# Hotkey: Ctrl+g
+Import-Module PSReadLine
+
+Set-PSReadLineKeyHandler -Key Ctrl+g -ScriptBlock {
+    param($key, $arg)
+
+    # Get current line and cursor position
+    $line   = $null
+    $cursor = $null
+    [Microsoft.PowerShell.PSConsoleReadLine]::GetBufferState([ref]$line, [ref]$cursor)
+
+    $prompt = $line.Trim()
+    if (-not $prompt) { return }
+
+    # Loading-Text vorbereiten
+    $placeholder = "(Loading answer... $prompt)"
+
+    # Replace current line with loading indicator
+    [Microsoft.PowerShell.PSConsoleReadLine]::Replace(0, $line.Length, $placeholder)
+    [Microsoft.PowerShell.PSConsoleReadLine]::SetCursorPosition($placeholder.Length)
+
+    $oldPref = $ErrorActionPreference
+    $ErrorActionPreference = 'Stop'
+    try {
+        # The call with sgpt
+        $result = & sgpt --shell --no-interaction "$prompt" 2>&1
+    }
+    catch {
+        $ErrorActionPreference = $oldPref
+
+        # If error: restore input
+        $currentLine = $null
+        $c = $null
+        [Microsoft.PowerShell.PSConsoleReadLine]::GetBufferState([ref]$currentLine, [ref]$c)
+        [Microsoft.PowerShell.PSConsoleReadLine]::Replace(0, $currentLine.Length, $line)
+
+        Write-Host "Error calling sgpt:" -ForegroundColor Red
+        Write-Host $_ -ForegroundColor Red
+        return
+    }
+    $ErrorActionPreference = $oldPref
+
+    if (-not $result) {
+        # if sgpt does not return anyting, also restore input
+        $currentLine = $null
+        $c = $null
+        [Microsoft.PowerShell.PSConsoleReadLine]::GetBufferState([ref]$currentLine, [ref]$c)
+        [Microsoft.PowerShell.PSConsoleReadLine]::Replace(0, $currentLine.Length, $line)
+
+        Write-Host "sgpt did not respond." -ForegroundColor Yellow
+        return
+    }
+
+    $cmd = ($result -join [Environment]::NewLine)
+
+    # Get placeholder line and replace with sgpt answer
+    $currentLine = $null
+    $c = $null
+    [Microsoft.PowerShell.PSConsoleReadLine]::GetBufferState([ref]$currentLine, [ref]$c)
+    [Microsoft.PowerShell.PSConsoleReadLine]::Replace(0, $currentLine.Length, $cmd)
+}
+```
+
 ### Generating code
 By using the `--code` or `-c` parameter, you can specifically request pure code output, for instance:
 ```shell


### PR DESCRIPTION
## Summary

This PR adds a PowerShell shell integration example to the README, similar to the existing Bash/Zsh hotkey integration for `sgpt`.  
The example uses `PSReadLine` to bind a hotkey (Ctrl+G) that:

- takes the current command line as a natural-language prompt,
- shows a temporary "loading" message while waiting for `sgpt`,
- replaces the entire input line with the generated shell command.

## Motivation

Currently, the README documents shell integration for Bash and Zsh, but PowerShell users have to figure out their own setup.  
The proposed snippet provides:

- a simple, copy-pasteable solution for PowerShell,
- behavior consistent with the Bash/Zsh hotkey workflow,
- clear UX feedback while the model is generating a command.

This improves the onboarding experience for Windows/PowerShell users.

## Implementation

The example uses:

- `PSReadLine` to register a key handler (e.g. `Ctrl+g`),
- `GetBufferState` to read the current input line as the prompt,
- `Replace` to:
  - first show a `(Loading answer... <prompt>)` placeholder,
  - then replace it with the `sgpt` output,
- `sgpt --shell --no-interaction` to generate a shell command suitable for direct execution.

Example code to be added to the README:

```powershell
Import-Module PSReadLine

Set-PSReadLineKeyHandler -Key Ctrl+g -ScriptBlock {
    param($key, $arg)

    # Read current line as natural-language prompt
    $line   = $null
    $cursor = $null
    [Microsoft.PowerShell.PSConsoleReadLine]::GetBufferState([ref]$line, [ref]$cursor)

    $prompt = $line.Trim()
    if (-not $prompt) { return }

    # Show loading placeholder in the input line
    $placeholder = "(Loading answer... $prompt)"
    [Microsoft.PowerShell.PSConsoleReadLine]::Replace(0, $line.Length, $placeholder)
    [Microsoft.PowerShell.PSConsoleReadLine]::SetCursorPosition($placeholder.Length)

    $oldPref = $ErrorActionPreference
    $ErrorActionPreference = 'Stop'
    try {
        # Call sgpt to generate a shell command
        $result = & sgpt --shell --no-interaction "$prompt" 2>&1
    }
    catch {
        $ErrorActionPreference = $oldPref

        # Restore original line on error
        $currentLine = $null
        $c = $null
        [Microsoft.PowerShell.PSConsoleReadLine]::GetBufferState([ref]$currentLine, [ref]$c)
        [Microsoft.PowerShell.PSConsoleReadLine]::Replace(0, $currentLine.Length, $line)

        Write-Host "Error calling sgpt:" -ForegroundColor Red
        Write-Host $_ -ForegroundColor Red
        return
    }
    $ErrorActionPreference = $oldPref

    if (-not $result) {
        # Restore original line if nothing was returned
        $currentLine = $null
        $c = $null
        [Microsoft.PowerShell.PSConsoleReadLine]::GetBufferState([ref]$currentLine, [ref]$c)
        [Microsoft.PowerShell.PSConsoleReadLine]::Replace(0, $currentLine.Length, $line)

        Write-Host "sgpt returned no output." -ForegroundColor Yellow
        return
    }

    # Join multi-line output into a single string (if needed)
    $cmd = ($result -join [Environment]::NewLine)

    # Replace the current line (placeholder) with the generated command
    $currentLine = $null
    $c = $null
    [Microsoft.PowerShell.PSConsoleReadLine]::GetBufferState([ref]$currentLine, [ref]$c)
    [Microsoft.PowerShell.PSConsoleReadLine]::Replace(0, $currentLine.Length, $cmd)
}
```

## Usage

- Ensure sgpt is installed and available in PATH.
- Open your PowerShell profile: `notepad $PROFILE`
- Paste the above snippet into the profile and save.
- Restart PowerShell (or run . $PROFILE).
- Type a natural-language command, e.g.:

"list all files in current folder"
- Press Ctrl+g:
The line temporarily becomes:
- (Loading answer... list all files in current folder)
- Once sgpt responds, the line is replaced by a Get-ChildItem command that you can review, edit, and execute.

## Notes
- The hotkey (Ctrl+g) can be adjusted by changing the -Key parameter.
- The loading text can be customized by modifying the $placeholder string.
- This example targets Windows PowerShell / PowerShell 7+ with PSReadLine available.