### PR TITLE
Expand ~ and $HOME in path config keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,7 @@ This is just some examples of what we can do using OpenAI GPT models, I'm sure y
 
 ### Runtime configuration file
 You can setup some parameters in runtime configuration file `~/.config/shell_gpt/.sgptrc`:
+Path values for `ROLE_STORAGE_PATH`, `OPENAI_FUNCTIONS_PATH`, `CHAT_CACHE_PATH`, and `CACHE_PATH` support `~` and `$HOME` expansion.
 ```text
 # API key, also it is possible to define OPENAI_API_KEY env.
 OPENAI_API_KEY=your_api_key

--- a/git-town.toml
+++ b/git-town.toml
@@ -1,0 +1,9 @@
+# See https://www.git-town.com/configuration-file for details
+
+[branches]
+main = "main"
+
+[hosting]
+dev-remote = "fork"
+forge-type = "github"
+github-connector = "gh"

--- a/sgpt/config.py
+++ b/sgpt/config.py
@@ -40,6 +40,13 @@ DEFAULT_CONFIG = {
     # New features might add their own config variables here.
 }
 
+PATH_CONFIG_KEYS = {
+    "ROLE_STORAGE_PATH",
+    "OPENAI_FUNCTIONS_PATH",
+    "CHAT_CACHE_PATH",
+    "CACHE_PATH",
+}
+
 
 class Config(dict):  # type: ignore
     def __init__(self, config_path: Path, **defaults: Any):
@@ -86,6 +93,8 @@ class Config(dict):  # type: ignore
         value = os.getenv(key) or super().get(key)
         if not value:
             raise UsageError(f"Missing config key: {key}")
+        if key in PATH_CONFIG_KEYS:
+            return os.path.expanduser(os.path.expandvars(value))
         return value
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+
+import pytest
+
+from sgpt.config import Config
+
+
+@pytest.mark.parametrize(
+    "key,suffix",
+    [
+        ("ROLE_STORAGE_PATH", "roles"),
+        ("OPENAI_FUNCTIONS_PATH", "functions"),
+        ("CHAT_CACHE_PATH", "chat_cache"),
+        ("CACHE_PATH", "cache"),
+    ],
+)
+@pytest.mark.parametrize("raw_prefix", ["~", "$HOME"])
+def test_path_keys_expand_home_from_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    key: str,
+    suffix: str,
+    raw_prefix: str,
+) -> None:
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+    config_path = tmp_path / ".sgptrc"
+    config_path.write_text(f"{key}={raw_prefix}/shell_gpt/{suffix}\n", encoding="utf-8")
+
+    config = Config(config_path)
+
+    assert config.get(key) == str(home / "shell_gpt" / suffix)
+
+
+def test_path_keys_expand_home_from_env_override(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+    config_path = tmp_path / ".sgptrc"
+    config_path.write_text("ROLE_STORAGE_PATH=/tmp/ignored\n", encoding="utf-8")
+    monkeypatch.setenv("ROLE_STORAGE_PATH", "$HOME/override/roles")
+
+    config = Config(config_path)
+
+    assert config.get("ROLE_STORAGE_PATH") == str(home / "override" / "roles")
+
+
+def test_non_path_key_keeps_literal_value(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / ".sgptrc"
+    config_path.write_text("DEFAULT_MODEL=$HOME/literal-model\n", encoding="utf-8")
+
+    config = Config(config_path)
+
+    assert config.get("DEFAULT_MODEL") == "$HOME/literal-model"


### PR DESCRIPTION
### Summary
ShellGPT config now expands `~` and `$HOME` (and other `$VARS`) for path-based settings so users can keep portable config values.

### Motivation
Today, values like `ROLE_STORAGE_PATH=~/...` are treated literally, which breaks role/function discovery and cache storage unless users hardcode absolute paths.

### Changes
- Expand user home and env vars for `ROLE_STORAGE_PATH`, `OPENAI_FUNCTIONS_PATH`, `CHAT_CACHE_PATH`, and `CACHE_PATH` in `Config.get()`
- Add unit tests covering expansion from both config file and env override
- Document the behavior in README

### Notes
Non-path config keys are intentionally left unexpanded to avoid surprising behavior.
