### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,25 +486,25 @@ ENTRYPOINT ["sgpt"]
 
 
 ### Using MiniMax
-[MiniMax](https://www.minimaxi.com/) provides powerful LLM models (MiniMax-M2.5, MiniMax-M2.5-highspeed) with an OpenAI-compatible API. ShellGPT has first-class support for MiniMax -- just set the `MINIMAX_API_KEY` environment variable and the model name:
+[MiniMax](https://www.minimaxi.com/) provides powerful LLM models with an OpenAI-compatible API. ShellGPT has first-class support for MiniMax -- just set the `MINIMAX_API_KEY` environment variable and the model name:
 ```shell
 export MINIMAX_API_KEY="your_minimax_api_key"
-export DEFAULT_MODEL="MiniMax-M2.5"
+export DEFAULT_MODEL="MiniMax-M2.7"
 sgpt "What is the fibonacci sequence"
 ```
 
 Alternatively, configure it in `~/.config/shell_gpt/.sgptrc`:
 ```text
-DEFAULT_MODEL=MiniMax-M2.5
+DEFAULT_MODEL=MiniMax-M2.7
 ```
 
-When `MINIMAX_API_KEY` is set, ShellGPT automatically routes requests to the MiniMax API endpoint (`https://api.minimax.io/v1`). Temperature is automatically clamped to the MiniMax-supported range (0.01-1.0). Available models include `MiniMax-M2.5` (204K context) and `MiniMax-M2.5-highspeed` (fast inference).
+When `MINIMAX_API_KEY` is set, ShellGPT automatically routes requests to the MiniMax API endpoint (`https://api.minimax.io/v1`). Temperature is automatically clamped to the MiniMax-supported range (0.01-1.0). Available models include `MiniMax-M2.7` (latest flagship with enhanced reasoning and coding), `MiniMax-M2.7-highspeed` (low-latency), `MiniMax-M2.5` (204K context), and `MiniMax-M2.5-highspeed` (fast inference).
 
 You can also use MiniMax with Docker:
 ```shell
 docker run --rm \
            --env MINIMAX_API_KEY=your_key \
-           --env DEFAULT_MODEL=MiniMax-M2.5 \
+           --env DEFAULT_MODEL=MiniMax-M2.7 \
            --volume gpt-cache:/tmp/shell_gpt \
        ghcr.io/ther1d/shell_gpt "summarize this text"
 ```

--- a/README.md
+++ b/README.md
@@ -489,22 +489,22 @@ ENTRYPOINT ["sgpt"]
 [MiniMax](https://www.minimaxi.com/) provides powerful LLM models with an OpenAI-compatible API. ShellGPT has first-class support for MiniMax -- just set the `MINIMAX_API_KEY` environment variable and the model name:
 ```shell
 export MINIMAX_API_KEY="your_minimax_api_key"
-export DEFAULT_MODEL="MiniMax-M2.7"
+export DEFAULT_MODEL="MiniMax-M3"
 sgpt "What is the fibonacci sequence"
 ```
 
 Alternatively, configure it in `~/.config/shell_gpt/.sgptrc`:
 ```text
-DEFAULT_MODEL=MiniMax-M2.7
+DEFAULT_MODEL=MiniMax-M3
 ```
 
-When `MINIMAX_API_KEY` is set, ShellGPT automatically routes requests to the MiniMax API endpoint (`https://api.minimax.io/v1`). Temperature is automatically clamped to the MiniMax-supported range (0.01-1.0). Available models include `MiniMax-M2.7` (latest flagship with enhanced reasoning and coding), `MiniMax-M2.7-highspeed` (low-latency), `MiniMax-M2.5` (204K context), and `MiniMax-M2.5-highspeed` (fast inference).
+When `MINIMAX_API_KEY` is set, ShellGPT automatically routes requests to the MiniMax API endpoint (`https://api.minimax.io/v1`). Temperature is automatically clamped to the MiniMax-supported range (0.01-1.0). Available models include `MiniMax-M3` (latest flagship, 512K context, supports image input), `MiniMax-M2.7` (previous generation), and `MiniMax-M2.7-highspeed` (low-latency).
 
 You can also use MiniMax with Docker:
 ```shell
 docker run --rm \
            --env MINIMAX_API_KEY=your_key \
-           --env DEFAULT_MODEL=MiniMax-M2.7 \
+           --env DEFAULT_MODEL=MiniMax-M3 \
            --volume gpt-cache:/tmp/shell_gpt \
        ghcr.io/ther1d/shell_gpt "summarize this text"
 ```

--- a/README.md
+++ b/README.md
@@ -485,6 +485,30 @@ ENTRYPOINT ["sgpt"]
 ```
 
 
+### Using MiniMax
+[MiniMax](https://www.minimaxi.com/) provides powerful LLM models (MiniMax-M2.5, MiniMax-M2.5-highspeed) with an OpenAI-compatible API. ShellGPT has first-class support for MiniMax -- just set the `MINIMAX_API_KEY` environment variable and the model name:
+```shell
+export MINIMAX_API_KEY="your_minimax_api_key"
+export DEFAULT_MODEL="MiniMax-M2.5"
+sgpt "What is the fibonacci sequence"
+```
+
+Alternatively, configure it in `~/.config/shell_gpt/.sgptrc`:
+```text
+DEFAULT_MODEL=MiniMax-M2.5
+```
+
+When `MINIMAX_API_KEY` is set, ShellGPT automatically routes requests to the MiniMax API endpoint (`https://api.minimax.io/v1`). Temperature is automatically clamped to the MiniMax-supported range (0.01-1.0). Available models include `MiniMax-M2.5` (204K context) and `MiniMax-M2.5-highspeed` (fast inference).
+
+You can also use MiniMax with Docker:
+```shell
+docker run --rm \
+           --env MINIMAX_API_KEY=your_key \
+           --env DEFAULT_MODEL=MiniMax-M2.5 \
+           --volume gpt-cache:/tmp/shell_gpt \
+       ghcr.io/ther1d/shell_gpt "summarize this text"
+```
+
 ## Additional documentation
 * [Azure integration](https://github.com/TheR1D/shell_gpt/wiki/Azure)
 * [Ollama integration](https://github.com/TheR1D/shell_gpt/wiki/Ollama)

--- a/sgpt/handlers/handler.py
+++ b/sgpt/handlers/handler.py
@@ -1,4 +1,5 @@
 import json
+import os
 from pathlib import Path
 from typing import Any, Callable, Dict, Generator, List, Optional
 
@@ -8,13 +9,25 @@ from ..function import get_function
 from ..printer import MarkdownPrinter, Printer, TextPrinter
 from ..role import DefaultRoles, SystemRole
 
+MINIMAX_API_BASE_URL = "https://api.minimax.io/v1"
+
 completion: Callable[..., Any] = lambda *args, **kwargs: Generator[Any, None, None]
 
 base_url = cfg.get("API_BASE_URL")
 use_litellm = cfg.get("USE_LITELLM") == "true"
+
+# Resolve API key: prefer MINIMAX_API_KEY when set, auto-configure base URL.
+minimax_api_key = os.getenv("MINIMAX_API_KEY", "")
+if minimax_api_key:
+    api_key = minimax_api_key
+    if base_url == "default":
+        base_url = MINIMAX_API_BASE_URL
+else:
+    api_key = cfg.get("OPENAI_API_KEY")
+
 additional_kwargs = {
     "timeout": int(cfg.get("REQUEST_TIMEOUT")),
-    "api_key": cfg.get("OPENAI_API_KEY"),
+    "api_key": api_key,
     "base_url": None if base_url == "default" else base_url,
 }
 
@@ -114,6 +127,10 @@ class Handler:
             additional_kwargs["tool_choice"] = "auto"
             additional_kwargs["tools"] = functions
             additional_kwargs["parallel_tool_calls"] = False
+
+        # MiniMax API requires temperature in (0.0, 1.0].
+        if model.lower().startswith("minimax") and temperature == 0.0:
+            temperature = 0.01
 
         response = completion(
             model=model,

--- a/tests/test_minimax.py
+++ b/tests/test_minimax.py
@@ -11,13 +11,13 @@ role = SystemRole.get(DefaultRoles.DEFAULT.value)
 
 
 @patch("sgpt.handlers.handler.completion")
-def test_minimax_model_temperature_clamping(completion):
-    """MiniMax models should have temperature clamped from 0.0 to 0.01."""
+def test_minimax_m3_model_temperature_clamping(completion):
+    """MiniMax-M3 should have temperature clamped from 0.0 to 0.01."""
     completion.return_value = mock_comp("Hello from MiniMax")
 
     args = {
         "prompt": "say hello",
-        "--model": "MiniMax-M2.7",
+        "--model": "MiniMax-M3",
     }
     result = runner.invoke(app, cmd_args(**args))
 
@@ -35,7 +35,7 @@ def test_minimax_model_nonzero_temperature_unchanged(completion):
 
     args = {
         "prompt": "be creative",
-        "--model": "MiniMax-M2.7",
+        "--model": "MiniMax-M3",
         "--temperature": "0.7",
     }
     result = runner.invoke(app, cmd_args(**args))
@@ -63,18 +63,18 @@ def test_minimax_highspeed_model(completion):
 
 
 @patch("sgpt.handlers.handler.completion")
-def test_minimax_m25_model_still_works(completion):
-    """Previous MiniMax-M2.5 model should still work with temperature clamping."""
-    completion.return_value = mock_comp("M2.5 response")
+def test_minimax_m27_model_still_works(completion):
+    """Previous generation MiniMax-M2.7 should still work with temperature clamping."""
+    completion.return_value = mock_comp("M2.7 response")
 
     args = {
         "prompt": "say hello",
-        "--model": "MiniMax-M2.5",
+        "--model": "MiniMax-M2.7",
     }
     result = runner.invoke(app, cmd_args(**args))
 
     assert result.exit_code == 0
-    assert "M2.5 response" in result.output
+    assert "M2.7 response" in result.output
     call_kwargs = completion.call_args
     assert call_kwargs[1]["temperature"] == 0.01 or call_kwargs.kwargs.get("temperature") == 0.01
 
@@ -110,7 +110,7 @@ def test_minimax_chat_mode(completion):
     args = {
         "prompt": "remember number 40",
         "--chat": chat_name,
-        "--model": "MiniMax-M2.7",
+        "--model": "MiniMax-M3",
     }
     result = runner.invoke(app, cmd_args(**args))
     assert result.exit_code == 0

--- a/tests/test_minimax.py
+++ b/tests/test_minimax.py
@@ -17,7 +17,7 @@ def test_minimax_model_temperature_clamping(completion):
 
     args = {
         "prompt": "say hello",
-        "--model": "MiniMax-M2.5",
+        "--model": "MiniMax-M2.7",
     }
     result = runner.invoke(app, cmd_args(**args))
 
@@ -35,7 +35,7 @@ def test_minimax_model_nonzero_temperature_unchanged(completion):
 
     args = {
         "prompt": "be creative",
-        "--model": "MiniMax-M2.5",
+        "--model": "MiniMax-M2.7",
         "--temperature": "0.7",
     }
     result = runner.invoke(app, cmd_args(**args))
@@ -47,17 +47,34 @@ def test_minimax_model_nonzero_temperature_unchanged(completion):
 
 @patch("sgpt.handlers.handler.completion")
 def test_minimax_highspeed_model(completion):
-    """MiniMax-M2.5-highspeed should also get temperature clamping."""
+    """MiniMax-M2.7-highspeed should also get temperature clamping."""
     completion.return_value = mock_comp("Fast response")
 
     args = {
         "prompt": "quick answer",
-        "--model": "minimax-m2.5-highspeed",
+        "--model": "MiniMax-M2.7-highspeed",
     }
     result = runner.invoke(app, cmd_args(**args))
 
     assert result.exit_code == 0
     assert "Fast response" in result.output
+    call_kwargs = completion.call_args
+    assert call_kwargs[1]["temperature"] == 0.01 or call_kwargs.kwargs.get("temperature") == 0.01
+
+
+@patch("sgpt.handlers.handler.completion")
+def test_minimax_m25_model_still_works(completion):
+    """Previous MiniMax-M2.5 model should still work with temperature clamping."""
+    completion.return_value = mock_comp("M2.5 response")
+
+    args = {
+        "prompt": "say hello",
+        "--model": "MiniMax-M2.5",
+    }
+    result = runner.invoke(app, cmd_args(**args))
+
+    assert result.exit_code == 0
+    assert "M2.5 response" in result.output
     call_kwargs = completion.call_args
     assert call_kwargs[1]["temperature"] == 0.01 or call_kwargs.kwargs.get("temperature") == 0.01
 
@@ -93,7 +110,7 @@ def test_minimax_chat_mode(completion):
     args = {
         "prompt": "remember number 40",
         "--chat": chat_name,
-        "--model": "MiniMax-M2.5",
+        "--model": "MiniMax-M2.7",
     }
     result = runner.invoke(app, cmd_args(**args))
     assert result.exit_code == 0

--- a/tests/test_minimax.py
+++ b/tests/test_minimax.py
@@ -1,0 +1,112 @@
+"""Unit tests for MiniMax provider integration."""
+
+import os
+from unittest.mock import patch
+
+from sgpt.role import DefaultRoles, SystemRole
+
+from .utils import app, cmd_args, comp_args, mock_comp, runner
+
+role = SystemRole.get(DefaultRoles.DEFAULT.value)
+
+
+@patch("sgpt.handlers.handler.completion")
+def test_minimax_model_temperature_clamping(completion):
+    """MiniMax models should have temperature clamped from 0.0 to 0.01."""
+    completion.return_value = mock_comp("Hello from MiniMax")
+
+    args = {
+        "prompt": "say hello",
+        "--model": "MiniMax-M2.5",
+    }
+    result = runner.invoke(app, cmd_args(**args))
+
+    assert result.exit_code == 0
+    assert "Hello from MiniMax" in result.output
+    # Default temperature is 0.0, but MiniMax requires > 0.0
+    call_kwargs = completion.call_args
+    assert call_kwargs[1]["temperature"] == 0.01 or call_kwargs.kwargs.get("temperature") == 0.01
+
+
+@patch("sgpt.handlers.handler.completion")
+def test_minimax_model_nonzero_temperature_unchanged(completion):
+    """Non-zero temperature should pass through unchanged for MiniMax models."""
+    completion.return_value = mock_comp("Creative output")
+
+    args = {
+        "prompt": "be creative",
+        "--model": "MiniMax-M2.5",
+        "--temperature": "0.7",
+    }
+    result = runner.invoke(app, cmd_args(**args))
+
+    assert result.exit_code == 0
+    call_kwargs = completion.call_args
+    assert call_kwargs[1]["temperature"] == 0.7 or call_kwargs.kwargs.get("temperature") == 0.7
+
+
+@patch("sgpt.handlers.handler.completion")
+def test_minimax_highspeed_model(completion):
+    """MiniMax-M2.5-highspeed should also get temperature clamping."""
+    completion.return_value = mock_comp("Fast response")
+
+    args = {
+        "prompt": "quick answer",
+        "--model": "minimax-m2.5-highspeed",
+    }
+    result = runner.invoke(app, cmd_args(**args))
+
+    assert result.exit_code == 0
+    assert "Fast response" in result.output
+    call_kwargs = completion.call_args
+    assert call_kwargs[1]["temperature"] == 0.01 or call_kwargs.kwargs.get("temperature") == 0.01
+
+
+@patch("sgpt.handlers.handler.completion")
+def test_non_minimax_model_zero_temperature(completion):
+    """Non-MiniMax models should keep temperature=0.0 unchanged."""
+    completion.return_value = mock_comp("Berlin")
+
+    args = {
+        "prompt": "capital of Germany?",
+        "--model": "gpt-4o",
+    }
+    result = runner.invoke(app, cmd_args(**args))
+
+    assert result.exit_code == 0
+    call_kwargs = completion.call_args
+    assert call_kwargs[1]["temperature"] == 0.0 or call_kwargs.kwargs.get("temperature") == 0.0
+
+
+@patch("sgpt.handlers.handler.completion")
+def test_minimax_chat_mode(completion):
+    """MiniMax should work in chat mode with temperature clamping."""
+    from pathlib import Path
+
+    from sgpt.config import cfg
+
+    completion.side_effect = [mock_comp("ok"), mock_comp("42")]
+    chat_name = "_test_minimax"
+    chat_path = Path(cfg.get("CHAT_CACHE_PATH")) / chat_name
+    chat_path.unlink(missing_ok=True)
+
+    args = {
+        "prompt": "remember number 40",
+        "--chat": chat_name,
+        "--model": "MiniMax-M2.5",
+    }
+    result = runner.invoke(app, cmd_args(**args))
+    assert result.exit_code == 0
+    assert "ok" in result.output
+
+    args["prompt"] = "add 2 to it"
+    result = runner.invoke(app, cmd_args(**args))
+    assert result.exit_code == 0
+    assert "42" in result.output
+
+    # Verify temperature was clamped in both calls
+    for call in completion.call_args_list:
+        temp = call[1].get("temperature", call.kwargs.get("temperature"))
+        assert temp == 0.01
+
+    chat_path.unlink(missing_ok=True)

--- a/tests/test_minimax_integration.py
+++ b/tests/test_minimax_integration.py
@@ -1,0 +1,70 @@
+"""Integration tests for MiniMax provider.
+
+These tests make real API calls to the MiniMax API.
+Set MINIMAX_API_KEY environment variable to run them.
+Run with: pytest tests/test_minimax_integration.py -v
+"""
+
+import os
+from unittest import TestCase
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+from sgpt.app import main
+
+runner = CliRunner()
+app = typer.Typer()
+app.command()(main)
+
+requires_minimax = pytest.mark.skipif(
+    not os.getenv("MINIMAX_API_KEY"),
+    reason="MINIMAX_API_KEY not set",
+)
+
+
+@requires_minimax
+class TestMiniMaxIntegration(TestCase):
+    """Integration tests that call the real MiniMax API."""
+
+    @staticmethod
+    def get_arguments(prompt, **kwargs):
+        arguments = [prompt]
+        for key, value in kwargs.items():
+            arguments.append(key)
+            if isinstance(value, bool):
+                continue
+            arguments.append(value)
+        arguments.append("--no-cache")
+        arguments.append("--no-functions")
+        return arguments
+
+    def test_minimax_default_prompt(self):
+        args = {
+            "prompt": "What is 2 + 2? Reply with just the number.",
+            "--model": "MiniMax-M2.5",
+        }
+        result = runner.invoke(app, self.get_arguments(**args))
+        assert result.exit_code == 0
+        assert "4" in result.output
+
+    def test_minimax_code_generation(self):
+        args = {
+            "prompt": "Write a Python function that returns 42",
+            "--model": "MiniMax-M2.5",
+            "--code": True,
+        }
+        result = runner.invoke(app, self.get_arguments(**args))
+        assert result.exit_code == 0
+        assert "42" in result.output
+
+    def test_minimax_with_temperature(self):
+        args = {
+            "prompt": "Say hello",
+            "--model": "MiniMax-M2.5",
+            "--temperature": "0.5",
+        }
+        result = runner.invoke(app, self.get_arguments(**args))
+        assert result.exit_code == 0
+        assert len(result.output.strip()) > 0

--- a/tests/test_minimax_integration.py
+++ b/tests/test_minimax_integration.py
@@ -40,7 +40,36 @@ class TestMiniMaxIntegration(TestCase):
         arguments.append("--no-functions")
         return arguments
 
-    def test_minimax_default_prompt(self):
+    def test_minimax_m27_default_prompt(self):
+        args = {
+            "prompt": "What is 2 + 2? Reply with just the number.",
+            "--model": "MiniMax-M2.7",
+        }
+        result = runner.invoke(app, self.get_arguments(**args))
+        assert result.exit_code == 0
+        assert "4" in result.output
+
+    def test_minimax_m27_code_generation(self):
+        args = {
+            "prompt": "Write a Python function that returns 42",
+            "--model": "MiniMax-M2.7",
+            "--code": True,
+        }
+        result = runner.invoke(app, self.get_arguments(**args))
+        assert result.exit_code == 0
+        assert "42" in result.output
+
+    def test_minimax_m27_with_temperature(self):
+        args = {
+            "prompt": "Say hello",
+            "--model": "MiniMax-M2.7",
+            "--temperature": "0.5",
+        }
+        result = runner.invoke(app, self.get_arguments(**args))
+        assert result.exit_code == 0
+        assert len(result.output.strip()) > 0
+
+    def test_minimax_m25_still_works(self):
         args = {
             "prompt": "What is 2 + 2? Reply with just the number.",
             "--model": "MiniMax-M2.5",
@@ -48,23 +77,3 @@ class TestMiniMaxIntegration(TestCase):
         result = runner.invoke(app, self.get_arguments(**args))
         assert result.exit_code == 0
         assert "4" in result.output
-
-    def test_minimax_code_generation(self):
-        args = {
-            "prompt": "Write a Python function that returns 42",
-            "--model": "MiniMax-M2.5",
-            "--code": True,
-        }
-        result = runner.invoke(app, self.get_arguments(**args))
-        assert result.exit_code == 0
-        assert "42" in result.output
-
-    def test_minimax_with_temperature(self):
-        args = {
-            "prompt": "Say hello",
-            "--model": "MiniMax-M2.5",
-            "--temperature": "0.5",
-        }
-        result = runner.invoke(app, self.get_arguments(**args))
-        assert result.exit_code == 0
-        assert len(result.output.strip()) > 0

--- a/tests/test_minimax_integration.py
+++ b/tests/test_minimax_integration.py
@@ -40,39 +40,39 @@ class TestMiniMaxIntegration(TestCase):
         arguments.append("--no-functions")
         return arguments
 
-    def test_minimax_m27_default_prompt(self):
+    def test_minimax_m3_default_prompt(self):
         args = {
             "prompt": "What is 2 + 2? Reply with just the number.",
-            "--model": "MiniMax-M2.7",
+            "--model": "MiniMax-M3",
         }
         result = runner.invoke(app, self.get_arguments(**args))
         assert result.exit_code == 0
         assert "4" in result.output
 
-    def test_minimax_m27_code_generation(self):
+    def test_minimax_m3_code_generation(self):
         args = {
             "prompt": "Write a Python function that returns 42",
-            "--model": "MiniMax-M2.7",
+            "--model": "MiniMax-M3",
             "--code": True,
         }
         result = runner.invoke(app, self.get_arguments(**args))
         assert result.exit_code == 0
         assert "42" in result.output
 
-    def test_minimax_m27_with_temperature(self):
+    def test_minimax_m3_with_temperature(self):
         args = {
             "prompt": "Say hello",
-            "--model": "MiniMax-M2.7",
+            "--model": "MiniMax-M3",
             "--temperature": "0.5",
         }
         result = runner.invoke(app, self.get_arguments(**args))
         assert result.exit_code == 0
         assert len(result.output.strip()) > 0
 
-    def test_minimax_m25_still_works(self):
+    def test_minimax_m27_still_works(self):
         args = {
             "prompt": "What is 2 + 2? Reply with just the number.",
-            "--model": "MiniMax-M2.5",
+            "--model": "MiniMax-M2.7",
         }
         result = runner.invoke(app, self.get_arguments(**args))
         assert result.exit_code == 0


### PR DESCRIPTION
## Summary
Upgrade the existing MiniMax provider integration to use `MiniMax-M3` as the recommended default model while keeping `MiniMax-M2.7` / `MiniMax-M2.7-highspeed` as alternatives.

## Changes
- `README.md`: default `DEFAULT_MODEL` switched to `MiniMax-M3` (env, config file, and Docker example) and model lineup updated to list M3 first
- `tests/test_minimax.py`: default-model temperature clamping and chat-mode tests use `MiniMax-M3`; the previous-generation test now exercises `MiniMax-M2.7`
- `tests/test_minimax_integration.py`: real-API integration tests use `MiniMax-M3` (default prompt, code generation, temperature); the previous-generation case exercises `MiniMax-M2.7`
- Removed all references to `MiniMax-M2.5` / `MiniMax-M2.5-highspeed`

## Why
`MiniMax-M3` is the latest flagship: 512K context window, up to 128K output, and image input support. Promoting it as the default showcases the new model and matches the upgrade guidance, while keeping `MiniMax-M2.7` available for users who prefer the previous generation.

## Testing
- All 6 unit tests in `tests/test_minimax.py` pass
- Integration test class `TestMiniMaxIntegration` updated and structured identically (skips when `MINIMAX_API_KEY` is unset)