### PR TITLE
Update litellm integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ pip install shell-gpt
 By default, ShellGPT uses OpenAI's API and GPT-4 model. You'll need an API key, you can generate one [here](https://platform.openai.com/api-keys). You will be prompted for your key which will then be stored in `~/.config/shell_gpt/.sgptrc`. OpenAI API is not free of charge, please refer to the [OpenAI pricing](https://openai.com/pricing) for more information.
 
 > [!TIP]
-> Alternatively, you can use locally hosted open source models which are available for free. To use local models, you will need to run your own LLM backend server such as [Ollama](https://github.com/ollama/ollama). To set up ShellGPT with Ollama, please follow this comprehensive [guide](https://github.com/TheR1D/shell_gpt/wiki/Ollama).
+> Alternatively, you can run open-source models locally for free. This requires setting up your own LLM backend, such as [Ollama](https://github.com/ollama/ollama). To get ShellGPT working with Ollama, follow this detailed [guide](https://github.com/TheR1D/shell_gpt/wiki/Ollama)
 >
 > **❗️Note that ShellGPT is not optimized for local models and may not work as expected.**
 
@@ -455,35 +455,6 @@ You also can use the provided `Dockerfile` to build your own image:
 ```shell
 docker build -t sgpt .
 ```
-
-### Docker + Ollama
-
-If you want to send your requests to an Ollama instance and run ShellGPT inside a Docker container, you need to adjust the Dockerfile and build the container yourself: the litellm package is needed and env variables need to be set correctly.
-
-Example Dockerfile:
-```
-FROM python:3-slim
-
-ENV DEFAULT_MODEL=ollama/mistral:7b-instruct-v0.2-q4_K_M
-ENV API_BASE_URL=http://10.10.10.10:11434
-ENV USE_LITELLM=true
-ENV OPENAI_API_KEY=bad_key
-ENV SHELL_INTERACTION=false
-ENV PRETTIFY_MARKDOWN=false
-ENV OS_NAME="Arch Linux"
-ENV SHELL_NAME=auto
-
-WORKDIR /app
-COPY . /app
-
-RUN apt-get update && apt-get install -y gcc
-RUN pip install --no-cache /app[litellm] && mkdir -p /tmp/shell_gpt
-
-VOLUME /tmp/shell_gpt
-
-ENTRYPOINT ["sgpt"]
-```
-
 
 ## Additional documentation
 * [Azure integration](https://github.com/TheR1D/shell_gpt/wiki/Azure)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
 
 [project.optional-dependencies]
 litellm = [
-    "litellm == 1.42.5"
+    "litellm == 1.83.4"
 ]
 test = [
     "pytest >= 7.2.2, < 8.0.0",

--- a/sgpt/app.py
+++ b/sgpt/app.py
@@ -102,7 +102,7 @@ def main(
     ),
     repl: str = typer.Option(
         None,
-        help="Start a REPL (Read–eval–print loop) session.",
+        help="Start a REPL (Read-eval-print loop) session.",
         rich_help_panel="Chat Options",
     ),
     show_chat: str = typer.Option(

--- a/sgpt/handlers/handler.py
+++ b/sgpt/handlers/handler.py
@@ -23,7 +23,6 @@ if use_litellm:
 
     completion = litellm.completion
     litellm.suppress_debug_info = True
-    additional_kwargs.pop("api_key")
 else:
     from openai import OpenAI
 


### PR DESCRIPTION
- Bump litellm from 1.42.5 to 1.83.4
- Keep api_key in additional_kwargs for litellm completion calls
- Remove outdated Docker + Ollama section from README
- Minor wording improvements in README
- Fix unicode dash in REPL help text