### PR TITLE
Fix startup with legacy function schemas

### DIFF
--- a/sgpt/function.py
+++ b/sgpt/function.py
@@ -12,7 +12,10 @@ class Function:
     def __init__(self, path: str):
         module = self._read(path)
         self._function = module.Function.execute
-        self._openai_schema = module.Function.openai_schema()
+        openai_schema = module.Function.openai_schema
+        self._openai_schema = (
+            openai_schema() if callable(openai_schema) else openai_schema
+        )
         self._name = self._openai_schema["function"]["name"]
 
     @property
@@ -45,7 +48,7 @@ class Function:
             )
         if not hasattr(module.Function, "openai_schema"):
             raise TypeError(
-                f"Function {module_name} must have an 'openai_schema' classmethod"
+                f"Function {module_name} must have an 'openai_schema' attribute"
             )
 
         return module

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,0 +1,45 @@
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+
+def test_legacy_function_schema_does_not_crash_import(tmp_path):
+    home = tmp_path / "home"
+    functions_path = home / ".config" / "shell_gpt" / "functions"
+    functions_path.mkdir(parents=True)
+    (functions_path / "legacy.py").write_text(
+        textwrap.dedent(
+            """
+            from typing import Any, ClassVar
+            from pydantic import BaseModel
+
+
+            class Function(BaseModel):
+                openai_schema: ClassVar[dict[str, Any]] = {
+                    "function": {"name": "legacy"}
+                }
+
+                @classmethod
+                def execute(cls):
+                    return "ok"
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    env["OPENAI_API_KEY"] = "test-key"
+
+    result = subprocess.run(
+        [sys.executable, "-m", "sgpt", "--help"],
+        cwd=Path(__file__).resolve().parents[1],
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Usage:" in result.stdout


### PR DESCRIPTION
Fixes #748.

Users who still have pre-1.5.0 function files can hit a startup crash because those classes expose `openai_schema` as a legacy attribute instead of the new classmethod. That breaks startup before commands like `sgpt --help` or `sgpt --install-functions` can run.

This keeps the current callable path and falls back to the legacy attribute form when present, so older function files no longer break startup. The new regression test exercises the reported `--help` path with a legacy function fixture in a clean HOME.

Validation:
- `OPENAI_API_KEY=test-key pytest tests/test_functions.py tests/test_default.py -q`
- `./scripts/lint.sh` (run in a Python 3.11 venv)