### PR TITLE
fix: replace md5 with sha256 for FIPS-compliant cache key generation

### DIFF
--- a/sgpt/cache.py
+++ b/sgpt/cache.py
@@ -1,5 +1,5 @@
 import json
-from hashlib import md5
+from hashlib import sha256
 from pathlib import Path
 from typing import Any, Callable, Generator, no_type_check
 
@@ -28,7 +28,7 @@ class Cache:
         """
 
         def wrapper(*args: Any, **kwargs: Any) -> Generator[str, None, None]:
-            key = md5(json.dumps((args[1:], kwargs)).encode("utf-8")).hexdigest()
+            key = sha256(json.dumps((args[1:], kwargs)).encode("utf-8")).hexdigest()
             file = self.cache_path / key
             if kwargs.pop("caching") and file.exists():
                 yield file.read_text()


### PR DESCRIPTION
Fixes #701

## Problem

ShellGPT fails immediately on FIPS-enabled systems because the cache uses MD5 to generate cache keys. MD5 is not approved for use on FIPS 140-2/140-3 compliant systems, causing a `ValueError` when `hashlib.md5()` is called.

## Solution

Replace `md5` with `sha256` for cache key generation. SHA-256 is FIPS-compliant and serves the same purpose here — producing a deterministic, fixed-length key from the request parameters. This is a non-cryptographic use case (cache key deduplication), so SHA-256 is a drop-in replacement with no functional difference.

**Note:** Existing cache files (named with MD5 hashes) will not be matched after this change, so the cache will be cold on first run. Old files will be gradually evicted by the existing `_delete_oldest_files` cleanup logic.

## Testing

- Verified that the cache key generation works correctly with SHA-256
- The change is minimal and contained to `sgpt/cache.py`