### PR TITLE
fix: sanitize lone surrogates from stdin to prevent UnicodeEncodeError

### DIFF
--- a/sgpt/app.py
+++ b/sgpt/app.py
@@ -172,6 +172,9 @@ def main(
             if "__sgpt__eof__" in line:
                 break
             stdin += line
+        # Sanitize surrogate characters that can cause UnicodeEncodeError when
+        # piping binary content (e.g. `git diff` on Windows).
+        stdin = stdin.encode("utf-8", errors="replace").decode("utf-8")
         prompt = f"{stdin}\n\n{prompt}" if prompt else stdin
         try:
             # Switch to stdin for interactive input.

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -1,3 +1,4 @@
+import io
 from pathlib import Path
 from unittest.mock import patch
 
@@ -36,6 +37,43 @@ def test_default_stdin(completion):
     completion.assert_called_once_with(**comp_args(role, stdin))
     assert result.exit_code == 0
     assert "Prague" in result.output
+
+
+@patch("sgpt.handlers.handler.completion")
+def test_stdin_with_surrogate_characters(completion):
+    """Stdin with lone surrogate characters must not raise UnicodeEncodeError.
+
+    On Windows, piping binary content (e.g. ``git diff`` on a repo with
+    binary files) causes Python's text-mode stdin to produce lone surrogates
+    via the surrogateescape error handler.  Without sanitisation the surrogates
+    propagate into the JSON payload and httpx raises::
+
+        UnicodeEncodeError: 'utf-8' codec can't encode characters: surrogates not allowed
+
+    The fix encodes the stdin string with ``errors='replace'`` before using it
+    as the prompt.  This test verifies the fix by injecting a mock stdin that
+    yields a line containing a lone surrogate and asserting the invocation
+    succeeds.
+    """
+    completion.return_value = mock_comp("ok")
+
+    stdin_with_surrogate = "diff --git a/file b/file\n\udcffbinary content\n"
+    mock_stdin = io.StringIO(stdin_with_surrogate)
+    mock_stdin.isatty = lambda: False  # type: ignore[attr-defined]
+
+    with patch("sgpt.app.sys") as mock_sys:
+        mock_sys.stdin = mock_stdin
+        mock_sys.name = "posix"
+
+        result = runner.invoke(app, cmd_args())
+
+    assert result.exit_code == 0, result.output
+    assert "ok" in result.output
+
+    # The prompt passed to the LLM must contain no lone surrogates.
+    call_messages = completion.call_args[1]["messages"]
+    user_content = next(m["content"] for m in call_messages if m["role"] == "user")
+    user_content.encode("utf-8")  # must not raise
 
 
 @patch("rich.console.Console.print")


### PR DESCRIPTION
Fixes #667

## Problem

On Windows, piping binary content (e.g. `git diff` on a repository with binary files) through stdin causes Python's text-mode stdin reader to produce lone surrogate characters via the `surrogateescape` error handler. These surrogates propagate into the JSON payload sent to the API, and httpx raises:

```
UnicodeEncodeError: 'utf-8' codec can't encode characters in position 1297-1298: surrogates not allowed
```

This affects any workflow that pipes content containing non-UTF-8 bytes to `sgpt`, most commonly on Windows but potentially on other systems with non-UTF-8 locales.

## Solution

After collecting all stdin lines into the `stdin` string, apply a single-pass sanitization:

```python
stdin = stdin.encode("utf-8", errors="replace").decode("utf-8")
```

This replaces any lone surrogate characters with the Unicode replacement character (`U+FFFD`) before the string is incorporated into the prompt and eventually serialized to JSON.

## Testing

- Added `test_stdin_with_surrogate_characters` in `tests/test_default.py` which injects a mock stdin containing a lone surrogate (`\udcff`) and verifies:
  1. The CLI exits with code 0 (no crash).
  2. The message content passed to the LLM is valid UTF-8 (`.encode("utf-8")` does not raise).
- All 30 existing tests continue to pass (`pytest tests/ --ignore=tests/_integration.py`).