### PR TITLE
fix: add click to dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
 dependencies = [
     "openai >= 2.0.0, < 3.0.0",
     "typer >= 0.7.0, < 1.0.0",
+    "click >= 8.0.0",
     "rich >= 13.1.0, < 14.0.0",
     "distro >= 1.8.0, < 2.0.0",
     'pyreadline3 >= 3.4.1, < 4.0.0; sys_platform == "win32"',


### PR DESCRIPTION
## Problem

`click` is imported directly in `sgpt/app.py`, `sgpt/utils.py`, and `sgpt/config.py` but not declared in `pyproject.toml` dependencies. It used to come transitively through `typer`, but `typer 0.26.7` dropped that dependency.

Fixes #771

## Fix

Add `click >= 8.0.0` to `[project] dependencies` in `pyproject.toml`.

## Verification

```bash
pip install -e .
sgpt --help  # No longer fails with ModuleNotFoundError: No module named 'click'
```
