### PR TITLE
fix: declare click runtime dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
+    "click >= 8.1.0, < 9.0.0",
     "openai >= 2.0.0, < 3.0.0",
     "typer >= 0.7.0, < 1.0.0",
     "rich >= 13.1.0, < 14.0.0",


### PR DESCRIPTION
Fixes #771.

`shell_gpt` imports Click directly from multiple modules (`sgpt/app.py`, `sgpt/config.py`, `sgpt/role.py`, `sgpt/utils.py`, and `sgpt/handlers/chat_handler.py`), but `click` is not declared as a runtime dependency. Clean installs can therefore fail before Typer's transitive dependency is available.

This adds `click >= 8.1.0, < 9.0.0` as a direct project dependency.

Verification from an ASCII temp path on Windows:
- `uv run --with-editable . python -c "import importlib.metadata as m; print([r for r in (m.requires('shell_gpt') or []) if r.lower().startswith('click')])"`
- `uv run --with-editable . sgpt --help`
- `uv run --with-editable . python -c "from click import UsageError; import sgpt.app, sgpt.config, sgpt.role, sgpt.utils, sgpt.handlers.chat_handler; print(UsageError.__name__)"`