### PR TITLE
feat(config): add sgptrc extra_body support

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,8 +363,10 @@ You can setup some parameters in runtime configuration file `~/.config/shell_gpt
 OPENAI_API_KEY=your_api_key
 # Base URL of the backend server. If "default" URL will be resolved based on --model.
 API_BASE_URL=default
-# Extra JSON body to merge into OpenAI chat completion requests.
-EXTRA_BODY=null
+# Extra JSON body to merge into OpenAI chat completion requests. Leave empty to disable.
+EXTRA_BODY=
+# Example:
+# EXTRA_BODY={"thinking":{"type":"disabled"}}
 # Max amount of cached message per chat session.
 CHAT_CACHE_LENGTH=100
 # Chat cache folder.

--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ OPENAI_API_KEY=your_api_key
 # Base URL of the backend server. If "default" URL will be resolved based on --model.
 API_BASE_URL=default
 # Extra JSON body to merge into OpenAI chat completion requests.
-EXTRA_BODY={"thinking":{"type":"disabled"}}
+EXTRA_BODY=null
 # Max amount of cached message per chat session.
 CHAT_CACHE_LENGTH=100
 # Chat cache folder.

--- a/README.md
+++ b/README.md
@@ -363,6 +363,8 @@ You can setup some parameters in runtime configuration file `~/.config/shell_gpt
 OPENAI_API_KEY=your_api_key
 # Base URL of the backend server. If "default" URL will be resolved based on --model.
 API_BASE_URL=default
+# Extra JSON body to merge into OpenAI chat completion requests.
+EXTRA_BODY={"thinking":{"type":"disabled"}}
 # Max amount of cached message per chat session.
 CHAT_CACHE_LENGTH=100
 # Chat cache folder.

--- a/sgpt/config.py
+++ b/sgpt/config.py
@@ -32,7 +32,7 @@ DEFAULT_CONFIG = {
     "OPENAI_USE_FUNCTIONS": os.getenv("OPENAI_USE_FUNCTIONS", "true"),
     "SHOW_FUNCTIONS_OUTPUT": os.getenv("SHOW_FUNCTIONS_OUTPUT", "false"),
     "API_BASE_URL": os.getenv("API_BASE_URL", "default"),
-    "EXTRA_BODY": os.getenv("EXTRA_BODY", "{}"),
+    "EXTRA_BODY": os.getenv("EXTRA_BODY", "null"),
     "PRETTIFY_MARKDOWN": os.getenv("PRETTIFY_MARKDOWN", "true"),
     "USE_LITELLM": os.getenv("USE_LITELLM", "false"),
     "SHELL_INTERACTION": os.getenv("SHELL_INTERACTION ", "true"),

--- a/sgpt/config.py
+++ b/sgpt/config.py
@@ -32,7 +32,7 @@ DEFAULT_CONFIG = {
     "OPENAI_USE_FUNCTIONS": os.getenv("OPENAI_USE_FUNCTIONS", "true"),
     "SHOW_FUNCTIONS_OUTPUT": os.getenv("SHOW_FUNCTIONS_OUTPUT", "false"),
     "API_BASE_URL": os.getenv("API_BASE_URL", "default"),
-    "EXTRA_BODY": os.getenv("EXTRA_BODY", "null"),
+    "EXTRA_BODY": os.getenv("EXTRA_BODY", ""),
     "PRETTIFY_MARKDOWN": os.getenv("PRETTIFY_MARKDOWN", "true"),
     "USE_LITELLM": os.getenv("USE_LITELLM", "false"),
     "SHELL_INTERACTION": os.getenv("SHELL_INTERACTION ", "true"),

--- a/sgpt/config.py
+++ b/sgpt/config.py
@@ -32,6 +32,7 @@ DEFAULT_CONFIG = {
     "OPENAI_USE_FUNCTIONS": os.getenv("OPENAI_USE_FUNCTIONS", "true"),
     "SHOW_FUNCTIONS_OUTPUT": os.getenv("SHOW_FUNCTIONS_OUTPUT", "false"),
     "API_BASE_URL": os.getenv("API_BASE_URL", "default"),
+    "EXTRA_BODY": os.getenv("EXTRA_BODY", "{}"),
     "PRETTIFY_MARKDOWN": os.getenv("PRETTIFY_MARKDOWN", "true"),
     "USE_LITELLM": os.getenv("USE_LITELLM", "false"),
     "SHELL_INTERACTION": os.getenv("SHELL_INTERACTION ", "true"),

--- a/sgpt/handlers/handler.py
+++ b/sgpt/handlers/handler.py
@@ -1,6 +1,9 @@
 import json
+import os
 from pathlib import Path
 from typing import Any, Callable, Dict, Generator, List, Optional
+
+from click import UsageError
 
 from ..cache import Cache
 from ..config import cfg
@@ -29,6 +32,26 @@ else:
     client = OpenAI(**additional_kwargs)  # type: ignore
     completion = client.chat.completions.create
     additional_kwargs = {}
+
+
+def parse_extra_body() -> Optional[Dict[str, Any]]:
+    extra_body = os.getenv("EXTRA_BODY")
+    if extra_body is None:
+        extra_body = cfg["EXTRA_BODY"] if "EXTRA_BODY" in cfg else "{}"
+
+    extra_body = extra_body.strip()
+    if not extra_body or extra_body == "{}":
+        return None
+
+    try:
+        parsed_extra_body = json.loads(extra_body)
+    except json.JSONDecodeError as error:
+        raise UsageError("EXTRA_BODY must be a valid JSON object.") from error
+
+    if not isinstance(parsed_extra_body, dict):
+        raise UsageError("EXTRA_BODY must be a JSON object.")
+
+    return parsed_extra_body
 
 
 class Handler:
@@ -101,6 +124,7 @@ class Handler:
         top_p: float,
         messages: List[Dict[str, Any]],
         functions: Optional[List[Dict[str, str]]],
+        extra_body: Optional[Dict[str, Any]],
     ) -> Generator[str, None, None]:
         tool_call_id = name = arguments = ""
         is_shell_role = self.role.name == DefaultRoles.SHELL.value
@@ -109,10 +133,14 @@ class Handler:
         if is_shell_role or is_code_role or is_dsc_shell_role:
             functions = None
 
+        request_kwargs = dict(additional_kwargs)
+        if extra_body:
+            request_kwargs["extra_body"] = extra_body
+
         if functions:
-            additional_kwargs["tool_choice"] = "auto"
-            additional_kwargs["tools"] = functions
-            additional_kwargs["parallel_tool_calls"] = False
+            request_kwargs["tool_choice"] = "auto"
+            request_kwargs["tools"] = functions
+            request_kwargs["parallel_tool_calls"] = False
 
         response = completion(
             model=model,
@@ -120,7 +148,7 @@ class Handler:
             top_p=top_p,
             messages=messages,
             stream=True,
-            **additional_kwargs,
+            **request_kwargs,
         )
 
         try:
@@ -156,6 +184,7 @@ class Handler:
                         top_p=top_p,
                         messages=messages,
                         functions=functions,
+                        extra_body=extra_body,
                         caching=False,
                     )
                     return
@@ -182,6 +211,7 @@ class Handler:
             top_p=top_p,
             messages=messages,
             functions=functions,
+            extra_body=parse_extra_body(),
             caching=caching,
             **kwargs,
         )

--- a/sgpt/handlers/handler.py
+++ b/sgpt/handlers/handler.py
@@ -37,16 +37,19 @@ else:
 def parse_extra_body() -> Optional[Dict[str, Any]]:
     extra_body = os.getenv("EXTRA_BODY")
     if extra_body is None:
-        extra_body = cfg["EXTRA_BODY"] if "EXTRA_BODY" in cfg else "{}"
+        extra_body = cfg["EXTRA_BODY"] if "EXTRA_BODY" in cfg else "null"
 
     extra_body = extra_body.strip()
-    if not extra_body or extra_body == "{}":
+    if not extra_body:
         return None
 
     try:
         parsed_extra_body = json.loads(extra_body)
     except json.JSONDecodeError as error:
         raise UsageError("EXTRA_BODY must be a valid JSON object.") from error
+
+    if parsed_extra_body is None:
+        return None
 
     if not isinstance(parsed_extra_body, dict):
         raise UsageError("EXTRA_BODY must be a JSON object.")

--- a/sgpt/handlers/handler.py
+++ b/sgpt/handlers/handler.py
@@ -37,7 +37,7 @@ else:
 def parse_extra_body() -> Optional[Dict[str, Any]]:
     extra_body = os.getenv("EXTRA_BODY")
     if extra_body is None:
-        extra_body = cfg["EXTRA_BODY"] if "EXTRA_BODY" in cfg else "null"
+        extra_body = cfg["EXTRA_BODY"] if "EXTRA_BODY" in cfg else ""
 
     extra_body = extra_body.strip()
     if not extra_body:

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -238,8 +238,8 @@ def test_extra_body_config_must_be_json_object(completion, monkeypatch):
     result = runner.invoke(app, cmd_args(prompt="quick answer"))
 
     completion.assert_not_called()
-    assert result.exit_code == 2
-    assert "EXTRA_BODY must be a JSON object." in result.output
+    assert result.exit_code != 0
+    assert str(result.exception) == "EXTRA_BODY must be a JSON object."
 
 
 @patch("sgpt.handlers.handler.completion")

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -216,8 +216,8 @@ def test_llm_options(completion):
 
 
 @patch("sgpt.handlers.handler.completion")
-def test_extra_body_config_defaults_to_null(completion, monkeypatch):
-    monkeypatch.setenv("EXTRA_BODY", "null")
+def test_extra_body_config_defaults_to_empty(completion, monkeypatch):
+    monkeypatch.setenv("EXTRA_BODY", "")
     completion.return_value = mock_comp("ok")
 
     args = {"prompt": "quick answer"}

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -216,6 +216,33 @@ def test_llm_options(completion):
 
 
 @patch("sgpt.handlers.handler.completion")
+def test_extra_body_config(completion, monkeypatch):
+    extra_body = {"thinking": {"type": "disabled"}}
+    monkeypatch.setenv("EXTRA_BODY", '{"thinking":{"type":"disabled"}}')
+    completion.return_value = mock_comp("ok")
+
+    args = {"prompt": "quick answer"}
+    result = runner.invoke(app, cmd_args(**args))
+
+    completion.assert_called_once_with(
+        **comp_args(role=role, prompt=args["prompt"], extra_body=extra_body)
+    )
+    assert result.exit_code == 0
+    assert "ok" in result.output
+
+
+@patch("sgpt.handlers.handler.completion")
+def test_extra_body_config_must_be_json_object(completion, monkeypatch):
+    monkeypatch.setenv("EXTRA_BODY", "[]")
+
+    result = runner.invoke(app, cmd_args(prompt="quick answer"))
+
+    completion.assert_not_called()
+    assert result.exit_code == 2
+    assert "EXTRA_BODY must be a JSON object." in result.output
+
+
+@patch("sgpt.handlers.handler.completion")
 def test_version(completion):
     args = {"--version": True}
     result = runner.invoke(app, cmd_args(**args))

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -216,6 +216,19 @@ def test_llm_options(completion):
 
 
 @patch("sgpt.handlers.handler.completion")
+def test_extra_body_config_defaults_to_null(completion, monkeypatch):
+    monkeypatch.setenv("EXTRA_BODY", "null")
+    completion.return_value = mock_comp("ok")
+
+    args = {"prompt": "quick answer"}
+    result = runner.invoke(app, cmd_args(**args))
+
+    completion.assert_called_once_with(**comp_args(role=role, prompt=args["prompt"]))
+    assert result.exit_code == 0
+    assert "ok" in result.output
+
+
+@patch("sgpt.handlers.handler.completion")
 def test_extra_body_config(completion, monkeypatch):
     extra_body = {"thinking": {"type": "disabled"}}
     monkeypatch.setenv("EXTRA_BODY", '{"thinking":{"type":"disabled"}}')


### PR DESCRIPTION
## Summary

Adds support for configuring OpenAI SDK `extra_body` through `.sgptrc`.

This allows users of OpenAI-compatible providers, such as DeepSeek, to pass provider-specific request body options without code changes.

Example:

```text
EXTRA_BODY={"thinking":{"type":"disabled"}}
```

By default, EXTRA_BODY is empty and no extra request body is sent.

## Related Issue
Fixes https://github.com/TheR1D/shell_gpt/issues/780