### PR TITLE
Ignore invalid chat cache JSON

### DIFF
--- a/sgpt/handlers/chat_handler.py
+++ b/sgpt/handlers/chat_handler.py
@@ -66,7 +66,10 @@ class ChatSession:
         file_path = self.storage_path / chat_id
         if not file_path.exists():
             return []
-        parsed_cache = json.loads(file_path.read_text())
+        try:
+            parsed_cache = json.loads(file_path.read_text())
+        except json.JSONDecodeError:
+            return []
         return parsed_cache if isinstance(parsed_cache, list) else []
 
     def _write(self, messages: List[Dict[str, str]], chat_id: str) -> None:

--- a/tests/test_chat_session.py
+++ b/tests/test_chat_session.py
@@ -1,0 +1,12 @@
+from sgpt.handlers.chat_handler import ChatHandler
+
+
+def test_chat_session_ignores_invalid_json_cache():
+    session = ChatHandler.chat_session
+    chat_id = "_invalid_cache"
+    cache_path = session.storage_path / chat_id
+    cache_path.write_text("{not valid json")
+
+    assert session.get_messages(chat_id) == []
+    assert not session.exists(chat_id)
+    cache_path.unlink()


### PR DESCRIPTION
## What changed

`ChatSession._read()` now treats invalid JSON cache files like an empty chat history instead of raising `JSONDecodeError`.

## Why

Chat cache files are local recoverable state. If a cache file is truncated or manually edited into invalid JSON, commands that inspect or continue that chat should not crash before the user can recover.

## Validation

- `OPENAI_API_KEY=test python -m pytest tests\test_chat_session.py -q`
- `python -m black --check sgpt\handlers\chat_handler.py tests\test_chat_session.py`