### PR TITLE
Make top-p configurable via .sgptrc (closes #425)

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,10 @@ CACHE_PATH=/tmp/shell_gpt/cache
 REQUEST_TIMEOUT=60
 # Default OpenAI model to use.
 DEFAULT_MODEL=gpt-5.4-mini
+# Default temperature for completions (0.0-2.0).
+DEFAULT_TEMPERATURE=0.0
+# Default top-p (nucleus sampling) for completions (0.0-1.0).
+DEFAULT_TOP_P=1.0
 # Default color for shell and code completions.
 DEFAULT_COLOR=magenta
 # When in --shell mode, default to "Y" for no input.

--- a/sgpt/app.py
+++ b/sgpt/app.py
@@ -41,7 +41,7 @@ def main(
         help="Randomness of generated output.",
     ),
     top_p: float = typer.Option(
-        1.0,
+        cfg.get("DEFAULT_TOP_P"),
         min=0.0,
         max=1.0,
         help="Limits highest probable tokens (words).",

--- a/sgpt/config.py
+++ b/sgpt/config.py
@@ -24,6 +24,7 @@ DEFAULT_CONFIG = {
     "REQUEST_TIMEOUT": int(os.getenv("REQUEST_TIMEOUT", "60")),
     "DEFAULT_MODEL": os.getenv("DEFAULT_MODEL", "gpt-5.4-mini"),
     "DEFAULT_TEMPERATURE": os.getenv("DEFAULT_TEMPERATURE", 0.0),
+    "DEFAULT_TOP_P": os.getenv("DEFAULT_TOP_P", 1.0),
     "DEFAULT_COLOR": os.getenv("DEFAULT_COLOR", "magenta"),
     "ROLE_STORAGE_PATH": os.getenv("ROLE_STORAGE_PATH", str(ROLE_STORAGE_PATH)),
     "DEFAULT_EXECUTE_SHELL_CMD": os.getenv("DEFAULT_EXECUTE_SHELL_CMD", "false"),


### PR DESCRIPTION
# PR: Make `top-p` (top-probability) configurable via `.sgptrc` — closes #425

## Summary
Issue #425 asks to set a default **temperature** and **top-probability** via the
runtime config file (`~/.config/shell_gpt/.sgptrc`).

- Temperature config support already landed in #723 (`DEFAULT_TEMPERATURE`).
- This PR completes the issue by making **`top-p`** config-driven too, via a new
  `DEFAULT_TOP_P` key. Previously `top_p` was hardcoded to `1.0` in `app.py`, so
  the config file had no effect on it.

## Changes
1. `sgpt/config.py` — add `DEFAULT_TOP_P` to `DEFAULT_CONFIG` (default `1.0`,
   overridable via `DEFAULT_TOP_P` env var, consistent with `DEFAULT_TEMPERATURE`).
2. `sgpt/app.py` — `top_p` typer.Option default now reads `cfg.get("DEFAULT_TOP_P")`
   instead of the literal `1.0`.
3. `README.md` — document both `DEFAULT_TEMPERATURE` and `DEFAULT_TOP_P` in the
   runtime config example block (temperature was previously undocumented).

## Behavior
- Default behavior is unchanged: `DEFAULT_TOP_P` defaults to `1.0`, identical to
  the previous hardcoded value.
- Users can now set `DEFAULT_TOP_P=0.9` (or any `0.0–1.0` value) in `.sgptrc` to
  apply a default nucleus-sampling probability without passing `--top-p` every run.
- Explicit `--top-p` on the command line still overrides the config, as before.

## Verification
- `python3 -m py_compile sgpt/config.py sgpt/app.py` passes.
- Existing test suite passes (run in isolated venv:
  `OPENAI_API_KEY=dummy sgpt-venv/bin/python -m pytest tests/ -q`).

## Test plan for maintainers
- [ ] `sgpt "hello"` with no `--top-p` uses `DEFAULT_TOP_P` from config (default 1.0).
- [ ] Setting `DEFAULT_TOP_P=0.5` in `.sgptrc` changes the default without flags.
- [ ] `--top-p 0.3` still overrides the config value.
